### PR TITLE
Fix to correct secret name when pulling account key

### DIFF
--- a/OpenTibia.Common.Contracts/OpenTibia.Common.Contracts.csproj
+++ b/OpenTibia.Common.Contracts/OpenTibia.Common.Contracts.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0-beta2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0-preview3.19554.8" />
     <PackageReference Include="Serilog" Version="2.9.1-dev-01151" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.1-dev-00209" />

--- a/OpenTibia.Common.Utilities.Testing/OpenTibia.Common.Utilities.Testing.csproj
+++ b/OpenTibia.Common.Utilities.Testing/OpenTibia.Common.Utilities.Testing.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20191115-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">

--- a/OpenTibia.Data.CosmosDB/ConfigurationRootExtensions.cs
+++ b/OpenTibia.Data.CosmosDB/ConfigurationRootExtensions.cs
@@ -35,7 +35,7 @@ namespace OpenTibia.Data.CosmosDB
             // configure options
             services.Configure<CosmosDbConfigurationOptions>(configuration.GetSection(nameof(CosmosDbConfigurationOptions)));
 
-            services.AddSingleton<IOpenTibiaDbContext, OpenTibiaCosmosDbContext>();
+            services.AddTransient<IOpenTibiaDbContext, OpenTibiaCosmosDbContext>();
         }
     }
 }

--- a/OpenTibia.Data.CosmosDB/OpenTibiaCosmosDbContext.cs
+++ b/OpenTibia.Data.CosmosDB/OpenTibiaCosmosDbContext.cs
@@ -112,7 +112,7 @@ namespace OpenTibia.Data.CosmosDB
                         if (OpenTibiaCosmosDbContext.accountkey == null)
                         {
                             // Attempt to retrieve secret using the provider.
-                            OpenTibiaCosmosDbContext.accountkey = this.SecretsProvider.GetSecretValueAsync(this.CosmosDbConfiguration.AccountEndpointSecretName).Result;
+                            OpenTibiaCosmosDbContext.accountkey = this.SecretsProvider.GetSecretValueAsync(this.CosmosDbConfiguration.AccountKeySecretName).Result;
                         }
                     }
                 }

--- a/OpenTibia.Providers.Azure/OpenTibia.Providers.Azure.csproj
+++ b/OpenTibia.Providers.Azure/OpenTibia.Providers.Azure.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0-preview3.19553.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.0-preview3.19553.2" />
     <PackageReference Include="Serilog" Version="2.9.1-dev-01151" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
       <PrivateAssets>all</PrivateAssets>

--- a/OpenTibia.Scheduling.Tests/OpenTibia.Scheduling.Tests.csproj
+++ b/OpenTibia.Scheduling.Tests/OpenTibia.Scheduling.Tests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20191115-01" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />


### PR DESCRIPTION
- Made context transient to get a new instance every time the service retrieves this type.
- Fixed a typo in which the wrong secret name was chosen to retrieve the account key from the Secrets Provider.

