### PR TITLE
set configuration root helper method of Azure providers

### DIFF
--- a/OpenTibia.Providers.Azure/ConfigurationRootExtensions.cs
+++ b/OpenTibia.Providers.Azure/ConfigurationRootExtensions.cs
@@ -1,0 +1,42 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="ConfigurationRootExtensions.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Providers.Azure
+{
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using OpenTibia.Common.Utilities;
+    using OpenTibia.Providers.Contracts;
+
+    /// <summary>
+    /// Static class that adds convenient methods to add the concrete implementations contained in this library.
+    /// </summary>
+    public static class ConfigurationRootExtensions
+    {
+        /// <summary>
+        /// Adds all implementations related to Azure providers contained in this library to the services collection.
+        /// Additionally, registers the options related to the concrete implementations added, such as:
+        ///     <see cref="KeyVaultSecretsProviderOptions"/>.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration reference.</param>
+        public static void AddAzureProviders(this IServiceCollection services, IConfiguration configuration)
+        {
+            configuration.ThrowIfNull(nameof(configuration));
+
+            // configure options
+            services.Configure<KeyVaultSecretsProviderOptions>(configuration.GetSection(nameof(KeyVaultSecretsProviderOptions)));
+
+            services.AddSingleton<ITokenProvider, AadTokenMsiBasedProvider>();
+            services.AddSingleton<ISecretsProvider, KeyVaultSecretsProvider>();
+        }
+    }
+}

--- a/OpenTibia.Providers.Azure/KeyVaultSecretsProvider.cs
+++ b/OpenTibia.Providers.Azure/KeyVaultSecretsProvider.cs
@@ -18,6 +18,7 @@ namespace OpenTibia.Providers.Azure
     using System.Threading.Tasks;
     using Microsoft.Azure.KeyVault;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Options;
     using OpenTibia.Common.Utilities;
     using OpenTibia.Providers.Contracts;
     using Serilog;
@@ -35,20 +36,18 @@ namespace OpenTibia.Providers.Azure
         /// <summary>
         /// Initializes a new instance of the <see cref="KeyVaultSecretsProvider"/> class.
         /// </summary>
-        /// <param name="configuration">A reference to the configuration.</param>
+        /// <param name="secretsProviderOptions">A reference to the secrets provider options.</param>
         /// <param name="tokenProvider">A reference to the token provider service to use to obtain access to the vault.</param>
         /// <param name="logger">A logger for this provider.</param>
         public KeyVaultSecretsProvider(
-            IConfiguration configuration,
+            IOptions<KeyVaultSecretsProviderOptions> secretsProviderOptions,
             ITokenProvider tokenProvider,
             ILogger logger)
         {
-            configuration.ThrowIfNull(nameof(configuration));
+            secretsProviderOptions?.Value.ThrowIfNull(nameof(secretsProviderOptions));
             tokenProvider.ThrowIfNull(nameof(tokenProvider));
 
-            var vaultBaseUri = configuration.GetValue<string>("VaultBaseUrl");
-
-            this.BaseUri = new Uri(vaultBaseUri);
+            this.BaseUri = new Uri(secretsProviderOptions.Value.VaultBaseUrl);
             this.keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(tokenProvider.TokenCallback));
             this.Logger = logger.ForContext<KeyVaultSecretsProvider>();
         }

--- a/OpenTibia.Providers.Azure/KeyVaultSecretsProviderOptions.cs
+++ b/OpenTibia.Providers.Azure/KeyVaultSecretsProviderOptions.cs
@@ -1,0 +1,24 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="KeyVaultSecretsProviderOptions.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Providers.Azure
+{
+    /// <summary>
+    /// Class that represents options for the Azure Key Vault secrets provider configuration.
+    /// </summary>
+    public class KeyVaultSecretsProviderOptions
+    {
+        /// <summary>
+        /// Gets or sets the base url for the Key Vault.
+        /// </summary>
+        public string VaultBaseUrl { get; set; }
+    }
+}

--- a/OpenTibia.Server.Standalone/Program.cs
+++ b/OpenTibia.Server.Standalone/Program.cs
@@ -114,10 +114,7 @@ namespace OpenTibia.Server.Standalone
             services.AddSingleton<IProtocolFactory, ProtocolFactory>();
             services.AddSingleton<IConnectionManager, ConnectionManager>();
 
-            // TODO: abstract these out as AddAzureProviders();
-            services.AddSingleton<ITokenProvider, AadTokenMsiBasedProvider>();
-            services.AddSingleton<ISecretsProvider, KeyVaultSecretsProvider>();
-
+            services.AddAzureProviders(hostingContext.Configuration);
             services.AddCosmosDBDatabaseContext(hostingContext.Configuration);
 
             // IOpenTibiaDbContext itself is added by the Add<DatabaseProvider>() call above.


### PR DESCRIPTION
Simple PR, added **KeyVaultSecretsProviderOptions** and a configuration root extension method to add the providers like they should have been:

` services.AddAzureProviders(hostingContext.Configuration);`

