### PR TITLE
Map slice descriptions bugfix, ITile decoupling, misc changes.

### DIFF
--- a/OpenTibia.Common.Utilities/BigInteger.cs
+++ b/OpenTibia.Common.Utilities/BigInteger.cs
@@ -8,38 +8,41 @@
 // See LICENSE file in the project root for full license information.
 // </copyright>
 // -----------------------------------------------------------------
-
+// For BigInteger.cs:
+//
+// Copyright(c) 2002 Chew Keong TAN
+// All rights reserved
+//
+// http://www.codeproject.com/KB/cs/biginteger.aspx
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, provided that the above copyright notice(s) and this
+// permission notice appear in all copies of the Software and that both the
+// above copyright notice(s) and this permission notice appear in supporting
+// documentation.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE
+// LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR
+// ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+// IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+// OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
 #pragma warning disable CA1303 // Do not pass literals as localized parameters
 namespace OpenTibia.Common.Utilities
 {
     using System;
     using System.Globalization;
 
-    /**
-        * Copyright (c) 2002 Chew Keong TAN
-        * All rights reserved
-        *
-        * http://www.codeproject.com/KB/cs/biginteger.aspx
-        *
-        * Permission is hereby granted, free of charge, to any person obtaining
-        * a copy of this software and associated documentation files (the "Software"),
-        * to deal in the Software without restriction, including without limitation
-        * the rights to use, copy, modify, merge, publish, distribute, and/or sell
-        * copies of the Software, and to permit persons to whom the Software is
-        * furnished to do so, provided that the above copyright notice(s) and this
-        * permission notice appear in all copies of the Software and that both the
-        * above copyright notice(s) and this permission notice appear in supporting
-        * documentation.
-        *
-        * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-        * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
-        * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE
-        * LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR
-        * ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
-        * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-        * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-        * */
+    /// <summary>
+    /// Class that represents a big integer.
+    /// </summary>
     public class BigInteger
     {
         /// <summary>
@@ -401,33 +404,48 @@ namespace OpenTibia.Common.Utilities
             }
         }
 
-        // ***********************************************************************
-        // Overloading of the typecast operator.
-        // For BigInteger bi = 10;
-        // ***********************************************************************
+        /// <summary>
+        /// Overloading of the typecast operator.
+        /// </summary>
+        /// <param name="value">The value to initialize with.</param>
         public static implicit operator BigInteger(long value)
         {
             return new BigInteger(value);
         }
 
+        /// <summary>
+        /// Overloading of the typecast operator.
+        /// </summary>
+        /// <param name="value">The value to initialize with.</param>
         public static implicit operator BigInteger(ulong value)
         {
             return new BigInteger(value);
         }
 
+        /// <summary>
+        /// Overloading of the typecast operator.
+        /// </summary>
+        /// <param name="value">The value to initialize with.</param>
         public static implicit operator BigInteger(int value)
         {
             return new BigInteger(value);
         }
 
+        /// <summary>
+        /// Overloading of the typecast operator.
+        /// </summary>
+        /// <param name="value">The value to initialize with.</param>
         public static implicit operator BigInteger(uint value)
         {
             return new BigInteger((ulong)value);
         }
 
-        // ***********************************************************************
-        // Overloading of addition operator
-        // ***********************************************************************
+        /// <summary>
+        /// Overloading of the addition operator.
+        /// </summary>
+        /// <param name="bi1">The first integer to add.</param>
+        /// <param name="bi2">The second integer to add.</param>
+        /// <returns>The addition of both integers.</returns>
         public static BigInteger operator +(BigInteger bi1, BigInteger bi2)
         {
             BigInteger result = new BigInteger
@@ -465,9 +483,11 @@ namespace OpenTibia.Common.Utilities
             return result;
         }
 
-        // ***********************************************************************
-        // Overloading of the unary ++ operator
-        // ***********************************************************************
+        /// <summary>
+        /// Overloading of the unary ++ operator.
+        /// </summary>
+        /// <param name="bi1">The integer to increment.</param>
+        /// <returns>The big integer with it's value incremented.</returns>
         public static BigInteger operator ++(BigInteger bi1)
         {
             BigInteger result = new BigInteger(bi1);
@@ -512,9 +532,12 @@ namespace OpenTibia.Common.Utilities
             return result;
         }
 
-        // ***********************************************************************
-        // Overloading of subtraction operator
-        // ***********************************************************************
+        /// <summary>
+        /// Overloading of the subtraction operator.
+        /// </summary>
+        /// <param name="bi1">The first integer to subtract from.</param>
+        /// <param name="bi2">The second integer to subtract.</param>
+        /// <returns>The result of the subtraction.</returns>
         public static BigInteger operator -(BigInteger bi1, BigInteger bi2)
         {
             bi1.ThrowIfNull(nameof(bi1));
@@ -571,9 +594,11 @@ namespace OpenTibia.Common.Utilities
             return result;
         }
 
-        // ***********************************************************************
-        // Overloading of the unary -- operator
-        // ***********************************************************************
+        /// <summary>
+        /// Overloading of the unary -- operator.
+        /// </summary>
+        /// <param name="bi1">The integer to decrement.</param>
+        /// <returns>The big integer with it's value decremented.</returns>
         public static BigInteger operator --(BigInteger bi1)
         {
             bi1.ThrowIfNull(nameof(bi1));
@@ -760,7 +785,7 @@ namespace OpenTibia.Common.Utilities
 
             BigInteger result = new BigInteger(bi1);
             result.dataLength = ShiftRight(result.data, shiftVal);
-            
+
             // negative
             if ((bi1.data[MaxLength - 1] & 0x80000000) != 0)
             {
@@ -1034,14 +1059,16 @@ namespace OpenTibia.Common.Utilities
             int lastPos = MaxLength - 1;
             bool dividendNeg = false;
 
-            if ((bi1.data[lastPos] & 0x80000000) != 0) // bi1 negative
+            if ((bi1.data[lastPos] & 0x80000000) != 0)
             {
+                // bi1 negative
                 bi1 = -bi1;
                 dividendNeg = true;
             }
 
-            if ((bi2.data[lastPos] & 0x80000000) != 0) // bi2 negative
+            if ((bi2.data[lastPos] & 0x80000000) != 0)
             {
+                // bi2 negative
                 bi2 = -bi2;
             }
 
@@ -1176,301 +1203,6 @@ namespace OpenTibia.Common.Utilities
             }
 
             return true;
-        }
-
-        // least significant bits at lower part of buffer
-        private static int ShiftLeft(uint[] buffer, int shiftVal)
-        {
-            int shiftAmount = 32;
-            int bufLen = buffer.Length;
-
-            while (bufLen > 1 && buffer[bufLen - 1] == 0)
-            {
-                bufLen--;
-            }
-
-            for (int count = shiftVal; count > 0;)
-            {
-                if (count < shiftAmount)
-                {
-                    shiftAmount = count;
-                }
-
-                ulong carry = 0;
-                for (int i = 0; i < bufLen; i++)
-                {
-                    ulong val = ((ulong)buffer[i]) << shiftAmount;
-                    val |= carry;
-
-                    buffer[i] = (uint)(val & 0xFFFFFFFF);
-                    carry = val >> 32;
-                }
-
-                if (carry != 0)
-                {
-                    if (bufLen + 1 <= buffer.Length)
-                    {
-                        buffer[bufLen] = (uint)carry;
-                        bufLen++;
-                    }
-                }
-
-                count -= shiftAmount;
-            }
-
-            return bufLen;
-        }
-
-        private static int ShiftRight(uint[] buffer, int shiftVal)
-        {
-            int shiftAmount = 32;
-            int invShift = 0;
-            int bufLen = buffer.Length;
-
-            while (bufLen > 1 && buffer[bufLen - 1] == 0)
-            {
-                bufLen--;
-            }
-
-            for (int count = shiftVal; count > 0;)
-            {
-                if (count < shiftAmount)
-                {
-                    shiftAmount = count;
-                    invShift = 32 - shiftAmount;
-                }
-
-                ulong carry = 0;
-                for (int i = bufLen - 1; i >= 0; i--)
-                {
-                    ulong val = ((ulong)buffer[i]) >> shiftAmount;
-                    val |= carry;
-
-                    carry = ((ulong)buffer[i]) << invShift;
-                    buffer[i] = (uint)val;
-                }
-
-                count -= shiftAmount;
-            }
-
-            while (bufLen > 1 && buffer[bufLen - 1] == 0)
-            {
-                bufLen--;
-            }
-
-            return bufLen;
-        }
-
-        // ***********************************************************************
-        // Private function that supports the division of two numbers with
-        // a divisor that has more than 1 digit.
-        //
-        // Algorithm taken from [1]
-        // ***********************************************************************
-        private static void MultiByteDivide(BigInteger bi1, BigInteger bi2, BigInteger outQuotient, BigInteger outRemainder)
-        {
-            bi1.ThrowIfNull(nameof(bi1));
-            bi2.ThrowIfNull(nameof(bi2));
-
-            outQuotient.ThrowIfNull(nameof(outQuotient));
-            outRemainder.ThrowIfNull(nameof(outRemainder));
-
-            uint[] result = new uint[MaxLength];
-
-            int remainderLen = bi1.dataLength + 1;
-            uint[] remainder = new uint[remainderLen];
-
-            uint mask = 0x80000000;
-            uint val = bi2.data[bi2.dataLength - 1];
-            int shift = 0, resultPos = 0;
-
-            while (mask != 0 && (val & mask) == 0)
-            {
-                shift++;
-                mask >>= 1;
-            }
-
-            for (int i = 0; i < bi1.dataLength; i++)
-            {
-                remainder[i] = bi1.data[i];
-            }
-
-            ShiftLeft(remainder, shift);
-            bi2 <<= shift;
-
-            int j = remainderLen - bi2.dataLength;
-            int pos = remainderLen - 1;
-
-            ulong firstDivisorByte = bi2.data[bi2.dataLength - 1];
-            ulong secondDivisorByte = bi2.data[bi2.dataLength - 2];
-
-            int divisorLen = bi2.dataLength + 1;
-            uint[] dividendPart = new uint[divisorLen];
-
-            while (j > 0)
-            {
-                ulong dividend = ((ulong)remainder[pos] << 32) + remainder[pos - 1];
-
-                ulong qHat = dividend / firstDivisorByte;
-                ulong rHat = dividend % firstDivisorByte;
-
-                bool done = false;
-                while (!done)
-                {
-                    done = true;
-
-                    if (qHat == 0x100000000 ||
-                       (qHat * secondDivisorByte) > ((rHat << 32) + remainder[pos - 2]))
-                    {
-                        qHat--;
-                        rHat += firstDivisorByte;
-
-                        if (rHat < 0x100000000)
-                        {
-                            done = false;
-                        }
-                    }
-                }
-
-                for (int h = 0; h < divisorLen; h++)
-                {
-                    dividendPart[h] = remainder[pos - h];
-                }
-
-                BigInteger kk = new BigInteger(dividendPart);
-                BigInteger ss = bi2 * (long)qHat;
-
-                while (ss > kk)
-                {
-                    qHat--;
-                    ss -= bi2;
-                }
-
-                BigInteger yy = kk - ss;
-
-                for (int h = 0; h < divisorLen; h++)
-                {
-                    remainder[pos - h] = yy.data[bi2.dataLength - h];
-                }
-
-                result[resultPos++] = (uint)qHat;
-
-                pos--;
-                j--;
-            }
-
-            outQuotient.dataLength = resultPos;
-            int y = 0;
-            for (int x = outQuotient.dataLength - 1; x >= 0; x--, y++)
-            {
-                outQuotient.data[y] = result[x];
-            }
-
-            for (; y < MaxLength; y++)
-            {
-                outQuotient.data[y] = 0;
-            }
-
-            while (outQuotient.dataLength > 1 && outQuotient.data[outQuotient.dataLength - 1] == 0)
-            {
-                outQuotient.dataLength--;
-            }
-
-            if (outQuotient.dataLength == 0)
-            {
-                outQuotient.dataLength = 1;
-            }
-
-            outRemainder.dataLength = ShiftRight(remainder, shift);
-
-            for (y = 0; y < outRemainder.dataLength; y++)
-            {
-                outRemainder.data[y] = remainder[y];
-            }
-
-            for (; y < MaxLength; y++)
-            {
-                outRemainder.data[y] = 0;
-            }
-        }
-
-        // ***********************************************************************
-        // Private function that supports the division of two numbers with
-        // a divisor that has only 1 digit.
-        // ***********************************************************************
-        private static void SingleByteDivide(BigInteger bi1, BigInteger bi2, BigInteger outQuotient, BigInteger outRemainder)
-        {
-            if (outQuotient == null)
-            {
-                throw new ArgumentNullException(nameof(outQuotient));
-            }
-
-            uint[] result = new uint[MaxLength];
-            int resultPos = 0;
-
-            // copy dividend to reminder
-            for (int i = 0; i < MaxLength; i++)
-            {
-                outRemainder.data[i] = bi1.data[i];
-            }
-
-            outRemainder.dataLength = bi1.dataLength;
-
-            while (outRemainder.dataLength > 1 && outRemainder.data[outRemainder.dataLength - 1] == 0)
-            {
-                outRemainder.dataLength--;
-            }
-
-            ulong divisor = bi2.data[0];
-            int pos = outRemainder.dataLength - 1;
-            ulong dividend = outRemainder.data[pos];
-
-            if (dividend >= divisor)
-            {
-                ulong quotient = dividend / divisor;
-                result[resultPos++] = (uint)quotient;
-
-                outRemainder.data[pos] = (uint)(dividend % divisor);
-            }
-
-            pos--;
-
-            while (pos >= 0)
-            {
-                dividend = ((ulong)outRemainder.data[pos + 1] << 32) + outRemainder.data[pos];
-                ulong quotient = dividend / divisor;
-                result[resultPos++] = (uint)quotient;
-
-                outRemainder.data[pos + 1] = 0;
-                outRemainder.data[pos--] = (uint)(dividend % divisor);
-            }
-
-            outQuotient.dataLength = resultPos;
-            int j = 0;
-            for (int i = outQuotient.dataLength - 1; i >= 0; i--, j++)
-            {
-                outQuotient.data[j] = result[i];
-            }
-
-            for (; j < MaxLength; j++)
-            {
-                outQuotient.data[j] = 0;
-            }
-
-            while (outQuotient.dataLength > 1 && outQuotient.data[outQuotient.dataLength - 1] == 0)
-            {
-                outQuotient.dataLength--;
-            }
-
-            if (outQuotient.dataLength == 0)
-            {
-                outQuotient.dataLength = 1;
-            }
-
-            while (outRemainder.dataLength > 1 && outRemainder.data[outRemainder.dataLength - 1] == 0)
-            {
-                outRemainder.dataLength--;
-            }
         }
 
         /// <summary>
@@ -1705,112 +1437,6 @@ namespace OpenTibia.Common.Utilities
             return resultNum;
         }
 
-        // ***********************************************************************
-        // Fast calculation of modular reduction using Barrett's reduction.
-        // Requires x < b^(2k), where b is the base.  In this case, base is
-        // 2^32 (uint).
-        //
-        // Reference [4]
-        // ***********************************************************************
-        private BigInteger BarrettReduction(BigInteger x, BigInteger n, BigInteger constant)
-        {
-            int k = n.dataLength,
-                kPlusOne = k + 1,
-                kMinusOne = k - 1;
-
-            BigInteger q1 = new BigInteger();
-
-            // q1 = x / b^(k-1)
-            for (int i = kMinusOne, j = 0; i < x.dataLength; i++, j++)
-            {
-                q1.data[j] = x.data[i];
-            }
-
-            q1.dataLength = x.dataLength - kMinusOne;
-            if (q1.dataLength <= 0)
-            {
-                q1.dataLength = 1;
-            }
-
-            BigInteger q2 = q1 * constant;
-            BigInteger q3 = new BigInteger();
-
-            // q3 = q2 / b^(k+1)
-            for (int i = kPlusOne, j = 0; i < q2.dataLength; i++, j++)
-            {
-                q3.data[j] = q2.data[i];
-            }
-
-            q3.dataLength = q2.dataLength - kPlusOne;
-            if (q3.dataLength <= 0)
-            {
-                q3.dataLength = 1;
-            }
-
-            // r1 = x mod b^(k+1)
-            // i.e. keep the lowest (k+1) words
-            BigInteger r1 = new BigInteger();
-            int lengthToCopy = (x.dataLength > kPlusOne) ? kPlusOne : x.dataLength;
-            for (int i = 0; i < lengthToCopy; i++)
-            {
-                r1.data[i] = x.data[i];
-            }
-
-            r1.dataLength = lengthToCopy;
-
-            // r2 = (q3 * n) mod b^(k+1)
-            // partial multiplication of q3 and n
-            BigInteger r2 = new BigInteger();
-            for (int i = 0; i < q3.dataLength; i++)
-            {
-                if (q3.data[i] == 0)
-                {
-                    continue;
-                }
-
-                ulong mcarry = 0;
-                int t = i;
-                for (int j = 0; j < n.dataLength && t < kPlusOne; j++, t++)
-                {
-                    // t = i + j
-                    ulong val = (q3.data[i] * (ulong)n.data[j]) +
-                                 r2.data[t] + mcarry;
-
-                    r2.data[t] = (uint)(val & 0xFFFFFFFF);
-                    mcarry = val >> 32;
-                }
-
-                if (t < kPlusOne)
-                {
-                    r2.data[t] = (uint)mcarry;
-                }
-            }
-
-            r2.dataLength = kPlusOne;
-            while (r2.dataLength > 1 && r2.data[r2.dataLength - 1] == 0)
-            {
-                r2.dataLength--;
-            }
-
-            r1 -= r2;
-
-            // negative
-            if ((r1.data[MaxLength - 1] & 0x80000000) != 0)
-            {
-                BigInteger val = new BigInteger();
-                val.data[kPlusOne] = 0x00000001;
-                val.dataLength = kPlusOne + 1;
-                r1 += val;
-            }
-
-            while (r1 >= n)
-            {
-                r1 -= n;
-            }
-
-            return r1;
-        }
-
         /// <summary>
         /// Returns the greatest common divisor between this and another <see cref="BigInteger"/>.
         /// </summary>
@@ -1955,7 +1581,7 @@ namespace OpenTibia.Common.Utilities
             long val = this.data[0];
 
             try
-            { 
+            {
                 // exception if maxLength = 1
                 val |= (long)this.data[1] << 32;
             }
@@ -2466,6 +2092,407 @@ namespace OpenTibia.Common.Utilities
             result[2] = qK;
 
             return result;
+        }
+
+        // least significant bits at lower part of buffer
+        private static int ShiftLeft(uint[] buffer, int shiftVal)
+        {
+            int shiftAmount = 32;
+            int bufLen = buffer.Length;
+
+            while (bufLen > 1 && buffer[bufLen - 1] == 0)
+            {
+                bufLen--;
+            }
+
+            for (int count = shiftVal; count > 0;)
+            {
+                if (count < shiftAmount)
+                {
+                    shiftAmount = count;
+                }
+
+                ulong carry = 0;
+                for (int i = 0; i < bufLen; i++)
+                {
+                    ulong val = ((ulong)buffer[i]) << shiftAmount;
+                    val |= carry;
+
+                    buffer[i] = (uint)(val & 0xFFFFFFFF);
+                    carry = val >> 32;
+                }
+
+                if (carry != 0)
+                {
+                    if (bufLen + 1 <= buffer.Length)
+                    {
+                        buffer[bufLen] = (uint)carry;
+                        bufLen++;
+                    }
+                }
+
+                count -= shiftAmount;
+            }
+
+            return bufLen;
+        }
+
+        private static int ShiftRight(uint[] buffer, int shiftVal)
+        {
+            int shiftAmount = 32;
+            int invShift = 0;
+            int bufLen = buffer.Length;
+
+            while (bufLen > 1 && buffer[bufLen - 1] == 0)
+            {
+                bufLen--;
+            }
+
+            for (int count = shiftVal; count > 0;)
+            {
+                if (count < shiftAmount)
+                {
+                    shiftAmount = count;
+                    invShift = 32 - shiftAmount;
+                }
+
+                ulong carry = 0;
+                for (int i = bufLen - 1; i >= 0; i--)
+                {
+                    ulong val = ((ulong)buffer[i]) >> shiftAmount;
+                    val |= carry;
+
+                    carry = ((ulong)buffer[i]) << invShift;
+                    buffer[i] = (uint)val;
+                }
+
+                count -= shiftAmount;
+            }
+
+            while (bufLen > 1 && buffer[bufLen - 1] == 0)
+            {
+                bufLen--;
+            }
+
+            return bufLen;
+        }
+
+        // ***********************************************************************
+        // Private function that supports the division of two numbers with
+        // a divisor that has more than 1 digit.
+        //
+        // Algorithm taken from [1]
+        // ***********************************************************************
+        private static void MultiByteDivide(BigInteger bi1, BigInteger bi2, BigInteger outQuotient, BigInteger outRemainder)
+        {
+            bi1.ThrowIfNull(nameof(bi1));
+            bi2.ThrowIfNull(nameof(bi2));
+
+            outQuotient.ThrowIfNull(nameof(outQuotient));
+            outRemainder.ThrowIfNull(nameof(outRemainder));
+
+            uint[] result = new uint[MaxLength];
+
+            int remainderLen = bi1.dataLength + 1;
+            uint[] remainder = new uint[remainderLen];
+
+            uint mask = 0x80000000;
+            uint val = bi2.data[bi2.dataLength - 1];
+            int shift = 0, resultPos = 0;
+
+            while (mask != 0 && (val & mask) == 0)
+            {
+                shift++;
+                mask >>= 1;
+            }
+
+            for (int i = 0; i < bi1.dataLength; i++)
+            {
+                remainder[i] = bi1.data[i];
+            }
+
+            ShiftLeft(remainder, shift);
+            bi2 <<= shift;
+
+            int j = remainderLen - bi2.dataLength;
+            int pos = remainderLen - 1;
+
+            ulong firstDivisorByte = bi2.data[bi2.dataLength - 1];
+            ulong secondDivisorByte = bi2.data[bi2.dataLength - 2];
+
+            int divisorLen = bi2.dataLength + 1;
+            uint[] dividendPart = new uint[divisorLen];
+
+            while (j > 0)
+            {
+                ulong dividend = ((ulong)remainder[pos] << 32) + remainder[pos - 1];
+
+                ulong qHat = dividend / firstDivisorByte;
+                ulong rHat = dividend % firstDivisorByte;
+
+                bool done = false;
+                while (!done)
+                {
+                    done = true;
+
+                    if (qHat == 0x100000000 ||
+                       (qHat * secondDivisorByte) > ((rHat << 32) + remainder[pos - 2]))
+                    {
+                        qHat--;
+                        rHat += firstDivisorByte;
+
+                        if (rHat < 0x100000000)
+                        {
+                            done = false;
+                        }
+                    }
+                }
+
+                for (int h = 0; h < divisorLen; h++)
+                {
+                    dividendPart[h] = remainder[pos - h];
+                }
+
+                BigInteger kk = new BigInteger(dividendPart);
+                BigInteger ss = bi2 * (long)qHat;
+
+                while (ss > kk)
+                {
+                    qHat--;
+                    ss -= bi2;
+                }
+
+                BigInteger yy = kk - ss;
+
+                for (int h = 0; h < divisorLen; h++)
+                {
+                    remainder[pos - h] = yy.data[bi2.dataLength - h];
+                }
+
+                result[resultPos++] = (uint)qHat;
+
+                pos--;
+                j--;
+            }
+
+            outQuotient.dataLength = resultPos;
+            int y = 0;
+            for (int x = outQuotient.dataLength - 1; x >= 0; x--, y++)
+            {
+                outQuotient.data[y] = result[x];
+            }
+
+            for (; y < MaxLength; y++)
+            {
+                outQuotient.data[y] = 0;
+            }
+
+            while (outQuotient.dataLength > 1 && outQuotient.data[outQuotient.dataLength - 1] == 0)
+            {
+                outQuotient.dataLength--;
+            }
+
+            if (outQuotient.dataLength == 0)
+            {
+                outQuotient.dataLength = 1;
+            }
+
+            outRemainder.dataLength = ShiftRight(remainder, shift);
+
+            for (y = 0; y < outRemainder.dataLength; y++)
+            {
+                outRemainder.data[y] = remainder[y];
+            }
+
+            for (; y < MaxLength; y++)
+            {
+                outRemainder.data[y] = 0;
+            }
+        }
+
+        // ***********************************************************************
+        // Private function that supports the division of two numbers with
+        // a divisor that has only 1 digit.
+        // ***********************************************************************
+        private static void SingleByteDivide(BigInteger bi1, BigInteger bi2, BigInteger outQuotient, BigInteger outRemainder)
+        {
+            if (outQuotient == null)
+            {
+                throw new ArgumentNullException(nameof(outQuotient));
+            }
+
+            uint[] result = new uint[MaxLength];
+            int resultPos = 0;
+
+            // copy dividend to reminder
+            for (int i = 0; i < MaxLength; i++)
+            {
+                outRemainder.data[i] = bi1.data[i];
+            }
+
+            outRemainder.dataLength = bi1.dataLength;
+
+            while (outRemainder.dataLength > 1 && outRemainder.data[outRemainder.dataLength - 1] == 0)
+            {
+                outRemainder.dataLength--;
+            }
+
+            ulong divisor = bi2.data[0];
+            int pos = outRemainder.dataLength - 1;
+            ulong dividend = outRemainder.data[pos];
+
+            if (dividend >= divisor)
+            {
+                ulong quotient = dividend / divisor;
+                result[resultPos++] = (uint)quotient;
+
+                outRemainder.data[pos] = (uint)(dividend % divisor);
+            }
+
+            pos--;
+
+            while (pos >= 0)
+            {
+                dividend = ((ulong)outRemainder.data[pos + 1] << 32) + outRemainder.data[pos];
+                ulong quotient = dividend / divisor;
+                result[resultPos++] = (uint)quotient;
+
+                outRemainder.data[pos + 1] = 0;
+                outRemainder.data[pos--] = (uint)(dividend % divisor);
+            }
+
+            outQuotient.dataLength = resultPos;
+            int j = 0;
+            for (int i = outQuotient.dataLength - 1; i >= 0; i--, j++)
+            {
+                outQuotient.data[j] = result[i];
+            }
+
+            for (; j < MaxLength; j++)
+            {
+                outQuotient.data[j] = 0;
+            }
+
+            while (outQuotient.dataLength > 1 && outQuotient.data[outQuotient.dataLength - 1] == 0)
+            {
+                outQuotient.dataLength--;
+            }
+
+            if (outQuotient.dataLength == 0)
+            {
+                outQuotient.dataLength = 1;
+            }
+
+            while (outRemainder.dataLength > 1 && outRemainder.data[outRemainder.dataLength - 1] == 0)
+            {
+                outRemainder.dataLength--;
+            }
+        }
+
+        // ***********************************************************************
+        // Fast calculation of modular reduction using Barrett's reduction.
+        // Requires x < b^(2k), where b is the base.  In this case, base is
+        // 2^32 (uint).
+        //
+        // Reference [4]
+        // ***********************************************************************
+        private BigInteger BarrettReduction(BigInteger x, BigInteger n, BigInteger constant)
+        {
+            int k = n.dataLength,
+                kPlusOne = k + 1,
+                kMinusOne = k - 1;
+
+            BigInteger q1 = new BigInteger();
+
+            // q1 = x / b^(k-1)
+            for (int i = kMinusOne, j = 0; i < x.dataLength; i++, j++)
+            {
+                q1.data[j] = x.data[i];
+            }
+
+            q1.dataLength = x.dataLength - kMinusOne;
+            if (q1.dataLength <= 0)
+            {
+                q1.dataLength = 1;
+            }
+
+            BigInteger q2 = q1 * constant;
+            BigInteger q3 = new BigInteger();
+
+            // q3 = q2 / b^(k+1)
+            for (int i = kPlusOne, j = 0; i < q2.dataLength; i++, j++)
+            {
+                q3.data[j] = q2.data[i];
+            }
+
+            q3.dataLength = q2.dataLength - kPlusOne;
+            if (q3.dataLength <= 0)
+            {
+                q3.dataLength = 1;
+            }
+
+            // r1 = x mod b^(k+1)
+            // i.e. keep the lowest (k+1) words
+            BigInteger r1 = new BigInteger();
+            int lengthToCopy = (x.dataLength > kPlusOne) ? kPlusOne : x.dataLength;
+            for (int i = 0; i < lengthToCopy; i++)
+            {
+                r1.data[i] = x.data[i];
+            }
+
+            r1.dataLength = lengthToCopy;
+
+            // r2 = (q3 * n) mod b^(k+1)
+            // partial multiplication of q3 and n
+            BigInteger r2 = new BigInteger();
+            for (int i = 0; i < q3.dataLength; i++)
+            {
+                if (q3.data[i] == 0)
+                {
+                    continue;
+                }
+
+                ulong mcarry = 0;
+                int t = i;
+                for (int j = 0; j < n.dataLength && t < kPlusOne; j++, t++)
+                {
+                    // t = i + j
+                    ulong val = (q3.data[i] * (ulong)n.data[j]) +
+                                 r2.data[t] + mcarry;
+
+                    r2.data[t] = (uint)(val & 0xFFFFFFFF);
+                    mcarry = val >> 32;
+                }
+
+                if (t < kPlusOne)
+                {
+                    r2.data[t] = (uint)mcarry;
+                }
+            }
+
+            r2.dataLength = kPlusOne;
+            while (r2.dataLength > 1 && r2.data[r2.dataLength - 1] == 0)
+            {
+                r2.dataLength--;
+            }
+
+            r1 -= r2;
+
+            // negative
+            if ((r1.data[MaxLength - 1] & 0x80000000) != 0)
+            {
+                BigInteger val = new BigInteger();
+                val.data[kPlusOne] = 0x00000001;
+                val.dataLength = kPlusOne + 1;
+                r1 += val;
+            }
+
+            while (r1 >= n)
+            {
+                r1 -= n;
+            }
+
+            return r1;
         }
     }
 }

--- a/OpenTibia.Communications.Contracts/Abstractions/INetworkMessage.cs
+++ b/OpenTibia.Communications.Contracts/Abstractions/INetworkMessage.cs
@@ -11,7 +11,6 @@
 
 namespace OpenTibia.Communications.Contracts.Abstractions
 {
-    using System;
     using System.Buffers;
 
     /// <summary>

--- a/OpenTibia.Communications.Handlers/ConfigurationRootExtensions.cs
+++ b/OpenTibia.Communications.Handlers/ConfigurationRootExtensions.cs
@@ -52,7 +52,7 @@ namespace OpenTibia.Communications.Handlers
             //services.AddSingleton<IHandler, ContainerUpHandler>();
             //services.AddSingleton<IHandler, FollowHandler>();
             //services.AddSingleton<IHandler, HouseWindowPostHandler>();
-            services.AddSingleton<IHandler, ItemMoveHandler>();
+            services.AddSingleton<IHandler, MoveThingHandler>();
             //services.AddSingleton<IHandler, ItemRotateHandler>();
             //services.AddSingleton<IHandler, ItemUseBattleHandler>();
             //services.AddSingleton<IHandler, ItemUseHandler>();

--- a/OpenTibia.Communications.Handlers/Game/LogoutHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/LogoutHandler.cs
@@ -61,7 +61,7 @@ namespace OpenTibia.Communications.Handlers.Game
                 return (false, null);
             }
 
-            if (this.Game.PlayerLogout(player))
+            if (this.Game.PlayerRequest_Logout(player))
             {
                 connection.Close();
             }

--- a/OpenTibia.Communications.Handlers/Game/LookAtHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/LookAtHandler.cs
@@ -11,7 +11,6 @@
 
 namespace OpenTibia.Communications.Handlers.Game
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using OpenTibia.Communications.Contracts.Abstractions;
@@ -19,9 +18,9 @@ namespace OpenTibia.Communications.Handlers.Game
     using OpenTibia.Communications.Handlers;
     using OpenTibia.Communications.Packets;
     using OpenTibia.Communications.Packets.Outgoing;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Enumerations;
-    using OpenTibia.Server.Contracts.Structs;
     using Serilog;
 
     /// <summary>

--- a/OpenTibia.Communications.Handlers/Game/LookAtHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/LookAtHandler.cs
@@ -94,7 +94,7 @@ namespace OpenTibia.Communications.Handlers.Game
                 switch (lookAtInfo.Location.Type)
                 {
                     case LocationType.Ground:
-                        thing = this.TileAccessor.GetTileAt(lookAtInfo.Location, out Tile targetTile) ? targetTile.GetThingAtStackPosition(this.CreatureFinder, lookAtInfo.StackPosition) : null;
+                        thing = this.TileAccessor.GetTileAt(lookAtInfo.Location, out ITile targetTile) ? targetTile.GetThingAtStackPosition(this.CreatureFinder, lookAtInfo.StackPosition) : null;
                         break;
                     case LocationType.Container:
                         // TODO: implement containers.

--- a/OpenTibia.Communications.Handlers/Game/PingRequestHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/PingRequestHandler.cs
@@ -12,7 +12,6 @@
 namespace OpenTibia.Communications.Handlers.Game
 {
     using System.Collections.Generic;
-    using System.Linq;
     using OpenTibia.Common.Utilities;
     using OpenTibia.Communications.Contracts.Abstractions;
     using OpenTibia.Communications.Contracts.Enumerations;

--- a/OpenTibia.Communications.Handlers/Game/PlayerLoginHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/PlayerLoginHandler.cs
@@ -164,7 +164,7 @@ namespace OpenTibia.Communications.Handlers.Game
                     // Set player status to online.
                     character.IsOnline = true;
 
-                    var player = this.Game.PlayerLogin(character, connection);
+                    var player = this.Game.PlayerRequest_Login(character, connection);
 
                     // Also, associate it to the new player.
                     connection.AssociateToPlayer(player.Id);

--- a/OpenTibia.Communications.Handlers/Game/PlayerTurnToDirectionHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/PlayerTurnToDirectionHandler.cs
@@ -56,7 +56,7 @@ namespace OpenTibia.Communications.Handlers.Game
             // No other content in message.
             if (this.CreatureFinder.FindCreatureById(connection.PlayerId) is IPlayer player)
             {
-                this.Game.PlayerTurnToDirection(player, this.Direction);
+                this.Game.PlayerRequest_TurnToDirection(player, this.Direction);
             }
 
             return (false, null);

--- a/OpenTibia.Communications.Handlers/Game/PlayerWalkOnDemandHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/PlayerWalkOnDemandHandler.cs
@@ -59,11 +59,9 @@ namespace OpenTibia.Communications.Handlers.Game
                 return (false, null);
             }
 
-            //player.ClearPendingActions();
-
             var responsePackets = new List<IOutgoingPacket>();
 
-            if (!this.Game.PlayerWalkToDirection(player, this.Direction))
+            if (!this.Game.PlayerRequest_WalkToDirection(player, this.Direction))
             {
                 responsePackets.Add(new PlayerWalkCancelPacket(this.Direction));
 

--- a/OpenTibia.Communications.Handlers/OpenTibia.Communications.Handlers.csproj
+++ b/OpenTibia.Communications.Handlers/OpenTibia.Communications.Handlers.csproj
@@ -35,7 +35,7 @@
     <AdditionalFiles Include="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Game\ItemMoveHandler.cs" />
+    <Compile Include="Game\MoveThingHandler.cs" />
     <Compile Include="Game\LogoutHandler.cs" />
     <Compile Include="Game\LookAtHandler.cs" />
     <Compile Include="Game\PingRequestHandler.cs" />

--- a/OpenTibia.Communications.Packets.Contracts/Abstractions/IThingMoveInfo.cs
+++ b/OpenTibia.Communications.Packets.Contracts/Abstractions/IThingMoveInfo.cs
@@ -14,7 +14,7 @@ namespace OpenTibia.Communications.Packets.Contracts.Abstractions
     using OpenTibia.Server.Contracts.Structs;
 
     /// <summary>
-    /// Interface for an thing movement information.
+    /// Interface for a thing movement information.
     /// </summary>
     public interface IThingMoveInfo
     {

--- a/OpenTibia.Communications.Packets.Contracts/Abstractions/IThingMoveInfo.cs
+++ b/OpenTibia.Communications.Packets.Contracts/Abstractions/IThingMoveInfo.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------
-// <copyright file="IItemMoveInfo.cs" company="2Dudes">
+// <copyright file="IThingMoveInfo.cs" company="2Dudes">
 // Copyright (c) 2018 2Dudes. All rights reserved.
 // Author: Jose L. Nunez de Caceres
 // http://linkedin.com/in/jlnunez89
@@ -14,32 +14,32 @@ namespace OpenTibia.Communications.Packets.Contracts.Abstractions
     using OpenTibia.Server.Contracts.Structs;
 
     /// <summary>
-    /// Interface for an item movement information.
+    /// Interface for an thing movement information.
     /// </summary>
-    public interface IItemMoveInfo
+    public interface IThingMoveInfo
     {
         /// <summary>
-        /// Gets the id of the item, as seen by the client.
+        /// Gets the id of the thing, as seen by the client.
         /// </summary>
-        ushort ClientId { get; }
+        ushort ThingClientId { get; }
 
         /// <summary>
-        /// Gets the location from which the item is being moved.
+        /// Gets the location from which the thing is being moved.
         /// </summary>
         Location FromLocation { get; }
 
         /// <summary>
-        /// Gets the position in the stack at the location from which the item is being moved.
+        /// Gets the position in the stack at the location from which the thing is being moved.
         /// </summary>
         byte FromStackPos { get; }
 
         /// <summary>
-        /// Gets the location to which the item is being moved.
+        /// Gets the location to which the thing is being moved.
         /// </summary>
         Location ToLocation { get; }
 
         /// <summary>
-        /// Gets the amount of the item being moved.
+        /// Gets the amount of the thing being moved.
         /// </summary>
         byte Count { get; }
     }

--- a/OpenTibia.Communications.Packets/Incoming/ThingMovePacket.cs
+++ b/OpenTibia.Communications.Packets/Incoming/ThingMovePacket.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------
-// <copyright file="ItemMovePacket.cs" company="2Dudes">
+// <copyright file="ThingMovePacket.cs" company="2Dudes">
 // Copyright (c) 2018 2Dudes. All rights reserved.
 // Author: Jose L. Nunez de Caceres
 // http://linkedin.com/in/jlnunez89
@@ -16,21 +16,21 @@ namespace OpenTibia.Communications.Packets.Incoming
     using OpenTibia.Server.Contracts.Structs;
 
     /// <summary>
-    /// Class that represents an item movement packet.
+    /// Class that represents an thing movement packet.
     /// </summary>
-    public class ItemMovePacket : IIncomingPacket, IItemMoveInfo
+    public class ThingMovePacket : IIncomingPacket, IThingMoveInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ItemMovePacket"/> class.
+        /// Initializes a new instance of the <see cref="ThingMovePacket"/> class.
         /// </summary>
-        /// <param name="fromLocation">The location from which the item is being moved.</param>
-        /// <param name="clientId">The id of the item being moved.</param>
-        /// <param name="fromStackPos">The position in the stack of the item being moved.</param>
-        /// <param name="toLocation">The location to which the item is being moved.</param>
-        /// <param name="count">The amount of the item being moved.</param>
-        public ItemMovePacket(Location fromLocation, ushort clientId, byte fromStackPos, Location toLocation, byte count)
+        /// <param name="fromLocation">The location from which the thing is being moved.</param>
+        /// <param name="thingClientId">The id of the thing being moved.</param>
+        /// <param name="fromStackPos">The position in the stack of the thing being moved.</param>
+        /// <param name="toLocation">The location to which the thing is being moved.</param>
+        /// <param name="count">The amount of the thing being moved.</param>
+        public ThingMovePacket(Location fromLocation, ushort thingClientId, byte fromStackPos, Location toLocation, byte count)
         {
-            this.ClientId = clientId;
+            this.ThingClientId = thingClientId;
 
             this.FromLocation = fromLocation;
             this.FromStackPos = fromStackPos;
@@ -41,27 +41,27 @@ namespace OpenTibia.Communications.Packets.Incoming
         }
 
         /// <summary>
-        /// Gets the id of the item, as seen by the client.
+        /// Gets the id of the thing, as seen by the client.
         /// </summary>
-        public ushort ClientId { get; }
+        public ushort ThingClientId { get; }
 
         /// <summary>
-        /// Gets the location from which the item is being moved.
+        /// Gets the location from which the thing is being moved.
         /// </summary>
         public Location FromLocation { get; }
 
         /// <summary>
-        /// Gets the position in the stack at the location from which the item is being moved.
+        /// Gets the position in the stack at the location from which the thing is being moved.
         /// </summary>
         public byte FromStackPos { get; }
 
         /// <summary>
-        /// Gets the location to which the item is being moved.
+        /// Gets the location to which the thing is being moved.
         /// </summary>
         public Location ToLocation { get; }
 
         /// <summary>
-        /// Gets the amount of the item being moved.
+        /// Gets the amount of the thing being moved.
         /// </summary>
         public byte Count { get; }
     }

--- a/OpenTibia.Communications.Packets/Incoming/ThingMovePacket.cs
+++ b/OpenTibia.Communications.Packets/Incoming/ThingMovePacket.cs
@@ -16,7 +16,7 @@ namespace OpenTibia.Communications.Packets.Incoming
     using OpenTibia.Server.Contracts.Structs;
 
     /// <summary>
-    /// Class that represents an thing movement packet.
+    /// Class that represents a thing movement packet.
     /// </summary>
     public class ThingMovePacket : IIncomingPacket, IThingMoveInfo
     {

--- a/OpenTibia.Communications.Packets/NetworkMessagePacketExtensions.cs
+++ b/OpenTibia.Communications.Packets/NetworkMessagePacketExtensions.cs
@@ -185,20 +185,20 @@ namespace OpenTibia.Communications.Packets
         }
 
         /// <summary>
-        /// Reads item movement information sent in the message.
+        /// Reads thing movement information sent in the message.
         /// </summary>
         /// <param name="message">The mesage to read the information from.</param>
-        /// <returns>The item movement information.</returns>
-        public static IItemMoveInfo ReadItemMoveInfo(this INetworkMessage message)
+        /// <returns>The thing movement information.</returns>
+        public static IThingMoveInfo ReadMoveThingInfo(this INetworkMessage message)
         {
-            return new ItemMovePacket(
+            return new ThingMovePacket(
                 fromLocation: new Location
                 {
                     X = message.GetUInt16(),
                     Y = message.GetUInt16(),
                     Z = (sbyte)message.GetByte(),
                 },
-                clientId: message.GetUInt16(),
+                thingClientId: message.GetUInt16(),
                 fromStackPos: message.GetByte(),
                 toLocation: new Location
                 {

--- a/OpenTibia.Communications.Packets/Outgoing/MapDescriptionPacket.cs
+++ b/OpenTibia.Communications.Packets/Outgoing/MapDescriptionPacket.cs
@@ -11,7 +11,6 @@
 
 namespace OpenTibia.Communications.Packets.Outgoing
 {
-    using System;
     using System.Buffers;
     using OpenTibia.Communications.Contracts.Abstractions;
     using OpenTibia.Communications.Contracts.Enumerations;

--- a/OpenTibia.Communications.Packets/Outgoing/UpdateTilePacket.cs
+++ b/OpenTibia.Communications.Packets/Outgoing/UpdateTilePacket.cs
@@ -11,7 +11,6 @@
 
 namespace OpenTibia.Communications.Packets.Outgoing
 {
-    using System;
     using System.Buffers;
     using OpenTibia.Communications.Contracts.Abstractions;
     using OpenTibia.Communications.Contracts.Enumerations;

--- a/OpenTibia.Communications/NetworkMessage.cs
+++ b/OpenTibia.Communications/NetworkMessage.cs
@@ -13,7 +13,6 @@ namespace OpenTibia.Communications
 {
     using System;
     using System.Buffers;
-    using System.Linq;
     using System.Text;
     using OpenTibia.Communications.Contracts.Abstractions;
     using OpenTibia.Security.Encryption;

--- a/OpenTibia.Data.CosmosDB/OpenTibiaCosmosDbContext.cs
+++ b/OpenTibia.Data.CosmosDB/OpenTibiaCosmosDbContext.cs
@@ -71,7 +71,7 @@ namespace OpenTibia.Data.CosmosDB
         }
 
         /// <summary>
-        /// Gets the application's context.
+        /// Gets the configuration options.
         /// </summary>
         public CosmosDbConfigurationOptions CosmosDbConfiguration { get; }
 

--- a/OpenTibia.Server.Contracts/Abstractions/IGame.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/IGame.cs
@@ -85,7 +85,7 @@ namespace OpenTibia.Server.Contracts.Abstractions
         /// </summary>
         /// <param name="character">The character that the player is logging in to.</param>
         /// <param name="connection">The connection that the player uses.</param>
-        /// <returns>An instance of the new <see cref="IPlayer"/> in the game, or null if it couldn't be instanciated.</returns>
+        /// <returns>An instance of the new <see cref="IPlayer"/> in the game, or null if it couldn't be instantiated.</returns>
         IPlayer PlayerRequest_Login(CharacterEntity character, IConnection connection);
 
         /// <summary>

--- a/OpenTibia.Server.Contracts/Abstractions/IGame.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/IGame.cs
@@ -45,44 +45,95 @@ namespace OpenTibia.Server.Contracts.Abstractions
         WorldState Status { get; }
 
         /// <summary>
+        /// Requests a notification be scheduled to be sent.
+        /// </summary>
+        /// <param name="notification">The notification.</param>
+        void RequestNofitication(INotification notification);
+
+        /// <summary>
+        /// Gets the description bytes of the map in behalf of a given player at a given location.
+        /// </summary>
+        /// <param name="player">The player for which the description is being retrieved for.</param>
+        /// <param name="location">The center location from which the description is being retrieved.</param>
+        /// <returns>A sequence of bytes representing the description.</returns>
+        ReadOnlySequence<byte> GetDescriptionOfMapForPlayer(IPlayer player, Location location);
+
+        /// <summary>
+        /// Gets the description bytes of the map in behalf of a given player for the specified window.
+        /// </summary>
+        /// <param name="player">The player for which the description is being retrieved for.</param>
+        /// <param name="startX">The starting X coordinate of the window.</param>
+        /// <param name="startY">The starting Y coordinate of the window.</param>
+        /// <param name="startZ">The starting Z coordinate of the window.</param>
+        /// <param name="endZ">The ending Z coordinate of the window.</param>
+        /// <param name="windowSizeX">The size of the window in X.</param>
+        /// <param name="windowSizeY">The size of the window in Y.</param>
+        /// <param name="startingZOffset">Optional. A starting offset for Z.</param>
+        /// <returns>A sequence of bytes representing the description.</returns>
+        ReadOnlySequence<byte> GetDescriptionOfMapForPlayer(IPlayer player, ushort startX, ushort startY, sbyte startZ, sbyte endZ, byte windowSizeX = IMap.DefaultWindowSizeX, byte windowSizeY = IMap.DefaultWindowSizeY, sbyte startingZOffset = 0);
+
+        /// <summary>
+        /// Gets the description bytes of a single tile of the map in behalf of a given player at a given location.
+        /// </summary>
+        /// <param name="player">The player for which the description is being retrieved for.</param>
+        /// <param name="location">The location from which the description of the tile is being retrieved.</param>
+        /// <returns>A sequence of bytes representing the tile's description.</returns>
+        ReadOnlySequence<byte> GetDescriptionOfTile(IPlayer player, Location location);
+
+        /// <summary>
         /// Attempts to log a player in to the game.
         /// </summary>
         /// <param name="character">The character that the player is logging in to.</param>
         /// <param name="connection">The connection that the player uses.</param>
-        /// <returns>An instance of the new <see cref="IPlayer"/> in the game.</returns>
-        IPlayer PlayerLogin(CharacterEntity character, IConnection connection);
+        /// <returns>An instance of the new <see cref="IPlayer"/> in the game, or null if it couldn't be instanciated.</returns>
+        IPlayer PlayerRequest_Login(CharacterEntity character, IConnection connection);
 
         /// <summary>
         /// Attempts to log a player out of the game.
         /// </summary>
         /// <param name="player">The player to attempt to attempt log out.</param>
-        /// <returns>True if the log-out was successful, false otherwise.</returns>
-        bool PlayerLogout(IPlayer player);
+        /// <returns>True if the log-out request was accepted, false otherwise.</returns>
+        bool PlayerRequest_Logout(IPlayer player);
 
         /// <summary>
         /// Attempts to schedule a creature's walk in the provided direction.
         /// </summary>
         /// <param name="player">The player making the request.</param>
         /// <param name="direction">The direction to walk to.</param>
-        /// <returns>True if the walk was possible and scheduled, false otherwise.</returns>
-        bool PlayerWalkToDirection(IPlayer player, Direction direction);
-
-        bool PlayerMoveThing(IPlayer player, ushort clientId, Location fromLocation, byte fromStackPos, Location toLocation, byte count);
-
-        void PlayerTurnToDirection(IPlayer player, Direction direction);
-
-        bool MoveThingBetweenTiles(IThing thing, Location fromTileLocation, byte fromTileStackPos, Location toTileLocation, byte amountToMove = 1, bool isTeleport = false);
+        /// <returns>True if the walk request was accepted, false otherwise.</returns>
+        bool PlayerRequest_WalkToDirection(IPlayer player, Direction direction);
 
         /// <summary>
-        /// Requests a notification be scheduled to be sent.
+        /// Attempts to turn a player to the requested direction.
         /// </summary>
-        /// <param name="notification">The notification.</param>
-        void RequestNofitication(INotification notification);
+        /// <param name="player">The player making the request.</param>
+        /// <param name="direction">The direction to turn to.</param>
+        /// <returns>True if the turn request was accepted, false otherwise.</returns>
+        bool PlayerRequest_TurnToDirection(IPlayer player, Direction direction);
 
-        ReadOnlySequence<byte> GetDescriptionOfMapForPlayer(IPlayer player, Location location);
+        /// <summary>
+        /// Attempts to move a thing on behalf of a player.
+        /// </summary>
+        /// <param name="player">The player making the request.</param>
+        /// <param name="thingId">The id of the thing attempting to be moved.</param>
+        /// <param name="fromLocation">The location from which the thing is being moved.</param>
+        /// <param name="fromStackPos">The position in the stack of the location from which the thing is being moved.</param>
+        /// <param name="toLocation">The location to which the thing is being moved.</param>
+        /// <param name="count">The amount of the thing that is being moved.</param>
+        /// <returns>True if the thing movement was accepted, false otherwise.</returns>
+        bool PlayerRequest_MoveThing(IPlayer player, ushort thingId, Location fromLocation, byte fromStackPos, Location toLocation, byte count);
 
-        ReadOnlySequence<byte> GetDescriptionOfMapForPlayer(IPlayer player, ushort startX, ushort startY, sbyte startZ, sbyte endZ, byte windowSizeX = IMap.DefaultWindowSizeX, byte windowSizeY = IMap.DefaultWindowSizeY, sbyte startingZOffset = 0);
-
-        ReadOnlySequence<byte> GetDescriptionOfTile(IPlayer player, Location location);
+        /// <summary>
+        /// Inmediately attempts to perform a thing movement between two tiles.
+        /// </summary>
+        /// <param name="thing">The thing being moved.</param>
+        /// <param name="fromTileLocation">The tile from which the movement is being performed.</param>
+        /// <param name="fromTileStackPos">The position in the stack of the tile from which the movement is being performed.</param>
+        /// <param name="toTileLocation">The tile to which the movement is being performed.</param>
+        /// <param name="amountToMove">Optional. The amount of the thing to move. Defaults to 1.</param>
+        /// <param name="isTeleport">Optional. A value indicating whether the move is considered a teleportation. Defaults to false.</param>
+        /// <returns>True if the movement was successfully performed, false otherwise.</returns>
+        /// <remarks>Changes game state, should only be performed after all pertinent validations happen.</remarks>
+        bool PerformThingMovementBetweenTiles(IThing thing, Location fromTileLocation, byte fromTileStackPos, Location toTileLocation, byte amountToMove = 1, bool isTeleport = false);
     }
 }

--- a/OpenTibia.Server.Contracts/Abstractions/IMap.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/IMap.cs
@@ -11,7 +11,6 @@
 
 namespace OpenTibia.Server.Contracts.Abstractions
 {
-    using System;
     using System.Buffers;
     using System.Collections.Generic;
     using OpenTibia.Server.Contracts;

--- a/OpenTibia.Server.Contracts/Abstractions/IMapLoader.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/IMapLoader.cs
@@ -42,7 +42,7 @@ namespace OpenTibia.Server.Contracts.Abstractions
         /// <param name="toY">The end Y coordinate for the load window.</param>
         /// <param name="fromZ">The start Z coordinate for the load window.</param>
         /// <param name="toZ">The end Z coordinate for the load window.</param>
-        /// <returns>A collection of ordered pairs containing the <see cref="Location"/> and its corresponding <see cref="Tile"/>.</returns>
-        IEnumerable<(Location Location, Tile Tile)> Load(int fromX, int toX, int fromY, int toY, sbyte fromZ, sbyte toZ);
+        /// <returns>A collection of ordered pairs containing the <see cref="Location"/> and its corresponding <see cref="ITile"/>.</returns>
+        IEnumerable<(Location Location, ITile Tile)> Load(int fromX, int toX, int fromY, int toY, sbyte fromZ, sbyte toZ);
     }
 }

--- a/OpenTibia.Server.Contracts/Abstractions/ISuffersExhaustion.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/ISuffersExhaustion.cs
@@ -36,5 +36,21 @@ namespace OpenTibia.Server.Contracts.Abstractions
         /// <param name="fromTime">The current time to calculate from.</param>
         /// <returns>The <see cref="TimeSpan"/> result.</returns>
         TimeSpan CalculateRemainingCooldownTime(ExhaustionType type, DateTimeOffset fromTime);
+
+        /// <summary>
+        /// Adds exhaustion of the given type.
+        /// </summary>
+        /// <param name="type">The type of exhaustion to add.</param>
+        /// <param name="fromTime">The reference time from which to add.</param>
+        /// <param name="milliseconds">The amount of time in milliseconds to add exhaustion for.</param>
+        void AddExhaustion(ExhaustionType type, DateTimeOffset fromTime, uint milliseconds);
+
+        /// <summary>
+        /// Adds exhaustion of the given type.
+        /// </summary>
+        /// <param name="type">The type of exhaustion to add.</param>
+        /// <param name="fromTime">The reference time from which to add.</param>
+        /// <param name="timeSpan">The amount of time to add exhaustion for.</param>
+        void AddExhaustion(ExhaustionType type, DateTimeOffset fromTime, TimeSpan timeSpan);
     }
 }

--- a/OpenTibia.Server.Contracts/Abstractions/ITile.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/ITile.cs
@@ -1,0 +1,46 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="ITile.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Server.Contracts.Abstractions
+{
+    using System;
+    using System.Collections.Generic;
+    using OpenTibia.Server.Contracts.Enumerations;
+
+    public interface ITile
+    {
+        int CreatureCount { get; }
+
+        IEnumerable<uint> CreatureIds { get; }
+
+        IEnumerable<IItem> DownItems { get; }
+
+        byte Flags { get; }
+
+        IItem Ground { get; }
+
+        DateTimeOffset LastModified { get; }
+
+        IEnumerable<IItem> TopItems1 { get; }
+
+        IEnumerable<IItem> TopItems2 { get; }
+
+        void AddThing(IItemFactory itemFactory, ref IThing thing, byte count = 1);
+
+        byte GetStackPositionOfThing(IThing thing);
+
+        IThing GetThingAtStackPosition(ICreatureFinder creatureFinder, byte stackPosition);
+
+        bool RemoveThing(IItemFactory itemFactory, ref IThing thing, byte count = 1);
+
+        void SetFlag(TileFlag flag);
+    }
+}

--- a/OpenTibia.Server.Contracts/Abstractions/ITileAccessor.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/ITileAccessor.cs
@@ -19,11 +19,11 @@ namespace OpenTibia.Server.Contracts.Abstractions
     public interface ITileAccessor
     {
         /// <summary>
-        /// Attempts to get a <see cref="Tile"/> at a given <see cref="Location"/>, if any.
+        /// Attempts to get a <see cref="ITile"/> at a given <see cref="Location"/>, if any.
         /// </summary>
         /// <param name="location">The location to get the file from.</param>
-        /// <param name="tile">A reference to the <see cref="Tile"/> found, if any.</param>
-        /// <returns>A value indicating whether a <see cref="Tile"/> was found, false otherwise.</returns>
-        bool GetTileAt(Location location, out Tile tile);
+        /// <param name="tile">A reference to the <see cref="ITile"/> found, if any.</param>
+        /// <returns>A value indicating whether a <see cref="ITile"/> was found, false otherwise.</returns>
+        bool GetTileAt(Location location, out ITile tile);
     }
 }

--- a/OpenTibia.Server.Contracts/Enumerations/TileFlag.cs
+++ b/OpenTibia.Server.Contracts/Enumerations/TileFlag.cs
@@ -11,8 +11,10 @@
 
 namespace OpenTibia.Server.Contracts.Enumerations
 {
+    using OpenTibia.Server.Contracts.Abstractions;
+
     /// <summary>
-    /// Enumerates the flags of a <see cref="Tile"/>.
+    /// Enumerates the flags of a <see cref="ITile"/>.
     /// </summary>
     public enum TileFlag : byte
     {

--- a/OpenTibia.Server.Contracts/Tile.cs
+++ b/OpenTibia.Server.Contracts/Tile.cs
@@ -9,7 +9,7 @@
 // </copyright>
 // -----------------------------------------------------------------
 
-namespace OpenTibia.Server.Contracts.Structs
+namespace OpenTibia.Server.Contracts
 {
     using System;
     using System.Collections.Generic;
@@ -21,7 +21,7 @@ namespace OpenTibia.Server.Contracts.Structs
     /// <summary>
     /// Class that represents a tile in the map.
     /// </summary>
-    public class Tile
+    public class Tile : ITile
     {
         /// <summary>
         /// Stores the ids of the creatures in the tile.

--- a/OpenTibia.Server.Parsing.Contracts/Abstractions/IParsedElement.cs
+++ b/OpenTibia.Server.Parsing.Contracts/Abstractions/IParsedElement.cs
@@ -24,7 +24,7 @@ namespace OpenTibia.Server.Parsing.Contracts.Abstractions
         int Id { get; }
 
         /// <summary>
-        /// Gets a value indicating whether  this element is a flag.
+        /// Gets a value indicating whether this element is a flag.
         /// </summary>
         bool IsFlag { get; }
 

--- a/OpenTibia.Server.Standalone/appsettings.json
+++ b/OpenTibia.Server.Standalone/appsettings.json
@@ -1,5 +1,7 @@
 {
-  "VaultBaseUrl": "https://opentibiacore.vault.azure.net/",
+  "KeyVaultSecretsProviderOptions": {
+    "VaultBaseUrl": "https://opentibiacore.vault.azure.net/"
+  },
   "SectorMapLoaderOptions": {
     "LiveMapDirectory": "map",
     "OriginalMapDirectory": "originalMap"

--- a/OpenTibia.Server/AllBlankMapLoader.cs
+++ b/OpenTibia.Server/AllBlankMapLoader.cs
@@ -14,7 +14,6 @@ namespace OpenTibia.Server
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
-    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Structs;
 
@@ -22,7 +21,7 @@ namespace OpenTibia.Server
     {
         public byte PercentageComplete => 0x64;
 
-        private ConcurrentDictionary<Location, Tile> tilesAndLocations;
+        private ConcurrentDictionary<Location, ITile> tilesAndLocations;
 
         private bool preloaded;
 
@@ -31,7 +30,7 @@ namespace OpenTibia.Server
             this.ItemFactory = itemFactory;
 
             this.preloaded = false;
-            this.tilesAndLocations = new ConcurrentDictionary<Location, Tile>();
+            this.tilesAndLocations = new ConcurrentDictionary<Location, ITile>();
         }
 
         public IItemFactory ItemFactory { get; }
@@ -41,11 +40,11 @@ namespace OpenTibia.Server
             return this.tilesAndLocations.ContainsKey(new Location() { X = x, Y = y, Z = z });
         }
 
-        public IEnumerable<(Location Location, Tile Tile)> Load(int fromX, int toX, int fromY, int toY, sbyte fromZ, sbyte toZ)
+        public IEnumerable<(Location Location, ITile Tile)> Load(int fromX, int toX, int fromY, int toY, sbyte fromZ, sbyte toZ)
         {
             if (fromZ != 7)
             {
-                return Enumerable.Empty<(Location, Tile)>();
+                return Enumerable.Empty<(Location, ITile)>();
             }
 
             if (!this.preloaded)
@@ -62,7 +61,7 @@ namespace OpenTibia.Server
                 return this.PreloadBlankMap(madeUpCenterLocation);
             }
 
-            var tuplesAdded = new List<(Location loc, Tile tile)>();
+            var tuplesAdded = new List<(Location loc, ITile tile)>();
 
             for (int x = fromX; x <= toX; x++)
             {
@@ -84,7 +83,7 @@ namespace OpenTibia.Server
             return tuplesAdded;
         }
 
-        private IEnumerable<(Location Location, Tile Tile)> PreloadBlankMap(Location centerLocation)
+        private IEnumerable<(Location Location, ITile Tile)> PreloadBlankMap(Location centerLocation)
         {
             return this.Load(centerLocation.X - 20, centerLocation.X + 20, centerLocation.Y - 10, centerLocation.Y + 10, centerLocation.Z, centerLocation.Z);
         }

--- a/OpenTibia.Server/AllBlankMapLoader.cs
+++ b/OpenTibia.Server/AllBlankMapLoader.cs
@@ -14,6 +14,7 @@ namespace OpenTibia.Server
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Structs;
 
@@ -51,7 +52,14 @@ namespace OpenTibia.Server
             {
                 this.preloaded = true;
 
-                return this.PreloadBlankMap(Map.VeteranStart);
+                var madeUpCenterLocation = new Location()
+                {
+                    X = 1000,
+                    Y = 1000,
+                    Z = 7,
+                };
+
+                return this.PreloadBlankMap(madeUpCenterLocation);
             }
 
             var tuplesAdded = new List<(Location loc, Tile tile)>();

--- a/OpenTibia.Server/CreatureFactory.cs
+++ b/OpenTibia.Server/CreatureFactory.cs
@@ -62,7 +62,7 @@ namespace OpenTibia.Server
 
                     throw new InvalidCastException($"{nameof(creatureMetadata)} must be castable to {nameof(PlayerCreationMetadata)} when {type} is used.");
 
-                // case CreatureType.Monster:
+                    // case CreatureType.Monster:
 
                     // if (creatureMetadata is MonsterCreationMetadata monsterMetadata)
                     // {

--- a/OpenTibia.Server/Game.cs
+++ b/OpenTibia.Server/Game.cs
@@ -179,7 +179,7 @@ namespace OpenTibia.Server
 
             playerThing.Location = Map.VeteranStart;
 
-            if (this.map.GetTileAt(player.Location, out Tile targetTile))
+            if (this.map.GetTileAt(player.Location, out ITile targetTile))
             {
                 targetTile.AddThing(this.ItemFactory, ref playerThing);
             }
@@ -199,7 +199,7 @@ namespace OpenTibia.Server
                 return false;
             }
 
-            if (!this.map.GetTileAt(player.Location, out Tile tile))
+            if (!this.map.GetTileAt(player.Location, out ITile tile))
             {
                 return false;
             }
@@ -246,7 +246,7 @@ namespace OpenTibia.Server
         /// <returns>True if the thing movement was accepted, false otherwise.</returns>
         public bool PlayerRequest_MoveThing(IPlayer player, ushort thingId, Location fromLocation, byte fromStackPos, Location toLocation, byte count)
         {
-            if (!this.map.GetTileAt(fromLocation, out Tile sourceTile))
+            if (!this.map.GetTileAt(fromLocation, out ITile sourceTile))
             {
                 return false;
             }
@@ -314,7 +314,7 @@ namespace OpenTibia.Server
             // TODO: should this be scheduled too?
             player.TurnToDirection(direction);
 
-            if (this.map.GetTileAt(player.Location, out Tile playerTile))
+            if (this.map.GetTileAt(player.Location, out ITile playerTile))
             {
                 var playerStackPos = playerTile.GetStackPositionOfThing(player);
 
@@ -373,7 +373,7 @@ namespace OpenTibia.Server
                     break;
             }
 
-            if (!this.map.GetTileAt(fromLoc, out Tile fromTile))
+            if (!this.map.GetTileAt(fromLoc, out ITile fromTile))
             {
                 return false;
             }
@@ -410,7 +410,7 @@ namespace OpenTibia.Server
         /// <remarks>Changes game state, should only be performed after all pertinent validations happen.</remarks>
         public bool PerformThingMovementBetweenTiles(IThing thing, Location fromTileLocation, byte fromTileStackPos, Location toTileLocation, byte amountToMove = 1, bool isTeleport = false)
         {
-            if (thing == null || !this.map.GetTileAt(fromTileLocation, out Tile fromTile) || !this.map.GetTileAt(toTileLocation, out Tile toTile))
+            if (thing == null || !this.map.GetTileAt(fromTileLocation, out ITile fromTile) || !this.map.GetTileAt(toTileLocation, out ITile toTile))
             {
                 return false;
             }

--- a/OpenTibia.Server/Map.cs
+++ b/OpenTibia.Server/Map.cs
@@ -34,12 +34,12 @@ namespace OpenTibia.Server
         public static Location VeteranStart = new Location { X = 32369, Y = 32241, Z = 7 };
 
         /// <summary>
-        /// Holds the <see cref="Tile"/>s data based on <see cref="Location"/>.
+        /// Holds the <see cref="ITile"/>s data based on <see cref="Location"/>.
         /// </summary>
-        private readonly ConcurrentDictionary<Location, Tile> tiles;
+        private readonly ConcurrentDictionary<Location, ITile> tiles;
 
         /// <summary>
-        /// Holds the cache of bytes for <see cref="Tile"/> descriptions, queried by <see cref="Location"/>.
+        /// Holds the cache of bytes for tile descriptions, queried by <see cref="Location"/>.
         /// </summary>
         private readonly IDictionary<Location, (DateTimeOffset lastUpdated, ReadOnlyMemory<byte> data, int[] lengths)> tilesCache;
 
@@ -64,7 +64,7 @@ namespace OpenTibia.Server
             this.Loader = mapLoader;
             this.CreatureFinder = creatureFinder;
 
-            this.tiles = new ConcurrentDictionary<Location, Tile>();
+            this.tiles = new ConcurrentDictionary<Location, ITile>();
 
             this.tilesCache = new Dictionary<Location, (DateTimeOffset, ReadOnlyMemory<byte>, int[] lengths)>();
             this.tilesCacheLock = new object();
@@ -231,7 +231,7 @@ namespace OpenTibia.Server
         /// <returns>A collection of description segments from the tile.</returns>
         public IEnumerable<MapDescriptionSegment> DescribeTileForPlayer(IPlayer player, Location location)
         {
-            if (!this.GetTileAt(location, out Tile tile))
+            if (!this.GetTileAt(location, out ITile tile))
             {
                 return Enumerable.Empty<MapDescriptionSegment>();
             }
@@ -418,12 +418,12 @@ namespace OpenTibia.Server
         }
 
         /// <summary>
-        /// Attempts to get a <see cref="Tile"/> at a given <see cref="Location"/>, if any.
+        /// Attempts to get a <see cref="ITile"/> at a given <see cref="Location"/>, if any.
         /// </summary>
         /// <param name="location">The location to get the file from.</param>
-        /// <param name="tile">A reference to the <see cref="Tile"/> found, if any.</param>
-        /// <returns>A value indicating whether a <see cref="Tile"/> was found, false otherwise.</returns>
-        public bool GetTileAt(Location location, out Tile tile)
+        /// <param name="tile">A reference to the <see cref="ITile"/> found, if any.</param>
+        /// <returns>A value indicating whether a <see cref="ITile"/> was found, false otherwise.</returns>
+        public bool GetTileAt(Location location, out ITile tile)
         {
             if (!this.Loader.HasLoaded(location.X, location.Y, location.Z))
             {

--- a/OpenTibia.Server/MovementEvents/BaseMovementEvent.cs
+++ b/OpenTibia.Server/MovementEvents/BaseMovementEvent.cs
@@ -86,7 +86,10 @@ namespace OpenTibia.Server.MovementEvents
             }
         }
 
-        private void NotifyOfFailure()
+        /// <summary>
+        /// Notifies the requestor player, if any,of this failure.
+        /// </summary>
+        protected void NotifyOfFailure()
         {
             if (this.Requestor is Player player)
             {

--- a/OpenTibia.Server/MovementEvents/EventConditions/LocationHasTileWithGroundEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/LocationHasTileWithGroundEventCondition.cs
@@ -51,7 +51,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
         /// <inheritdoc/>
         public bool Evaluate()
         {
-            return this.TileAccessor.GetTileAt(this.Location, out Tile tile) && tile.Ground != null;
+            return this.TileAccessor.GetTileAt(this.Location, out ITile tile) && tile.Ground != null;
         }
     }
 }

--- a/OpenTibia.Server/MovementEvents/EventConditions/LocationHasTileWithGroundEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/LocationHasTileWithGroundEventCondition.cs
@@ -13,6 +13,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
 {
     using OpenTibia.Common.Utilities;
     using OpenTibia.Scheduling.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Structs;
 

--- a/OpenTibia.Server/MovementEvents/EventConditions/LocationNotAviodEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/LocationNotAviodEventCondition.cs
@@ -76,7 +76,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
         {
             var requestor = this.RequestorId == 0 ? null : this.CreatureFinder.FindCreatureById(this.RequestorId);
 
-            this.TileAccessor.GetTileAt(this.Location, out Tile destTile);
+            this.TileAccessor.GetTileAt(this.Location, out ITile destTile);
 
             if (requestor == null || this.Thing == null)
             {

--- a/OpenTibia.Server/MovementEvents/EventConditions/LocationNotAviodEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/LocationNotAviodEventCondition.cs
@@ -13,6 +13,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
 {
     using OpenTibia.Common.Utilities;
     using OpenTibia.Scheduling.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Structs;
 

--- a/OpenTibia.Server/MovementEvents/EventConditions/LocationNotObstructedEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/LocationNotObstructedEventCondition.cs
@@ -76,7 +76,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
         {
             var requestor = this.RequestorId == 0 ? null : this.CreatureFinder.FindCreatureById(this.RequestorId);
 
-            this.TileAccessor.GetTileAt(this.Location, out Tile destTile);
+            this.TileAccessor.GetTileAt(this.Location, out ITile destTile);
 
             if (requestor == null || this.Thing == null)
             {

--- a/OpenTibia.Server/MovementEvents/EventConditions/LocationNotObstructedEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/LocationNotObstructedEventCondition.cs
@@ -13,6 +13,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
 {
     using OpenTibia.Common.Utilities;
     using OpenTibia.Scheduling.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Structs;
 

--- a/OpenTibia.Server/MovementEvents/EventConditions/TileContainsThingEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/TileContainsThingEventCondition.cs
@@ -13,6 +13,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
 {
     using System;
     using OpenTibia.Scheduling.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Structs;
 

--- a/OpenTibia.Server/MovementEvents/EventConditions/TileContainsThingEventCondition.cs
+++ b/OpenTibia.Server/MovementEvents/EventConditions/TileContainsThingEventCondition.cs
@@ -74,7 +74,7 @@ namespace OpenTibia.Server.MovementEvents.EventConditions
                 return false;
             }
 
-            if (!this.TileAccessor.GetTileAt(this.Location, out Tile sourceTile) /*|| !sourceTile.HasThing(this.Thing)*/)
+            if (!this.TileAccessor.GetTileAt(this.Location, out ITile sourceTile) /*|| !sourceTile.HasThing(this.Thing)*/)
             {
                 // This tile no longer has the thing, or it's obstructed (i.e. someone placed something on top of it).
                 return false;

--- a/OpenTibia.Server/MovementEvents/OnMapCreatureMovementEvent.cs
+++ b/OpenTibia.Server/MovementEvents/OnMapCreatureMovementEvent.cs
@@ -46,9 +46,8 @@ namespace OpenTibia.Server.MovementEvents
             Location fromLocation,
             byte fromStackPos,
             Location toLocation,
-            bool isTeleport = false,
-            byte count = 1)
-            : base(logger, game, connectionManager, tileAccessor, creatureFinder, requestorId, creatureMoving, fromLocation, fromStackPos, toLocation, count, isTeleport)
+            bool isTeleport = false)
+            : base(logger, game, connectionManager, tileAccessor, creatureFinder, requestorId, creatureMoving, fromLocation, fromStackPos, toLocation, 1, isTeleport)
         {
             // Don't add any conditions if this wasn't a creature requesting, i.e. if the request comes from a script.
             if (!isTeleport && this.Requestor != null)

--- a/OpenTibia.Server/MovementEvents/OnMapMovementEvent.cs
+++ b/OpenTibia.Server/MovementEvents/OnMapMovementEvent.cs
@@ -76,7 +76,12 @@ namespace OpenTibia.Server.MovementEvents
             {
                 bool moveSuccessful = game.PerformThingMovementBetweenTiles(thingMoving, fromLocation, fromStackPos, toLocation, count, isTeleport);
 
-                if (moveSuccessful && this.Requestor is IPlayer player && player != thingMoving)
+                if (!moveSuccessful)
+                {
+                    // handles check for isPlayer.
+                    this.NotifyOfFailure();
+                }
+                else if (this.Requestor is IPlayer player && player != thingMoving)
                 {
                     var directionToDestination = player.Location.DirectionTo(toLocation);
 

--- a/OpenTibia.Server/MovementEvents/OnMapMovementEvent.cs
+++ b/OpenTibia.Server/MovementEvents/OnMapMovementEvent.cs
@@ -72,7 +72,17 @@ namespace OpenTibia.Server.MovementEvents
             this.Conditions.Add(new LocationsMatchEventCondition(thingMoving?.Location ?? default, fromLocation));
             this.Conditions.Add(new TileContainsThingEventCondition(tileAccessor, thingMoving, fromLocation, count));
 
-            this.ActionsOnPass.Add(new GenericEventAction(() => { game.MoveThingBetweenTiles(thingMoving, fromLocation, fromStackPos, toLocation, count, isTeleport); }));
+            this.ActionsOnPass.Add(new GenericEventAction(() =>
+            {
+                bool moveSuccessful = game.PerformThingMovementBetweenTiles(thingMoving, fromLocation, fromStackPos, toLocation, count, isTeleport);
+
+                if (moveSuccessful && this.Requestor is IPlayer player && player != thingMoving)
+                {
+                    var directionToDestination = player.Location.DirectionTo(toLocation);
+
+                    game.PlayerRequest_TurnToDirection(player, directionToDestination);
+                }
+            }));
         }
     }
 }

--- a/OpenTibia.Server/Notifications/CreatureMovedNotification.cs
+++ b/OpenTibia.Server/Notifications/CreatureMovedNotification.cs
@@ -320,16 +320,16 @@ namespace OpenTibia.Server.Notifications
             //       .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .     ---
             //
             // x = target start of window (~) to refresh.
-            var offset = new Location()
+            var windowStartLocation = new Location()
             {
                 // -8
-                X = -((IMap.DefaultWindowSizeX / 2) - 1),
+                X = this.Arguments.OldLocation.X - ((IMap.DefaultWindowSizeX / 2) - 1),
 
-                // -7
-                Y = -(IMap.DefaultWindowSizeY / 2),
+                // -6
+                Y = this.Arguments.NewLocation.Y - ((IMap.DefaultWindowSizeY / 2) - 1),
+
+                Z = this.Arguments.NewLocation.Z,
             };
-
-            var windowStartLocation = this.Arguments.OldLocation + offset;
 
             return new MapPartialDescriptionPacket(
                 OutgoingGamePacketType.MapSliceNorth,
@@ -366,16 +366,16 @@ namespace OpenTibia.Server.Notifications
             //       x  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~  ~
             //
             // x = target start of window (~) to refresh.
-            var offset = new Location()
+            var windowStartLocation = new Location()
             {
                 // -8
-                X = -((IMap.DefaultWindowSizeX / 2) - 1),
+                X = this.Arguments.OldLocation.X - ((IMap.DefaultWindowSizeX / 2) - 1),
 
                 // +7
-                Y = IMap.DefaultWindowSizeY / 2,
-            };
+                Y = this.Arguments.NewLocation.Y + (IMap.DefaultWindowSizeY / 2),
 
-            var windowStartLocation = this.Arguments.NewLocation + offset;
+                Z = this.Arguments.NewLocation.Z,
+            };
 
             return new MapPartialDescriptionPacket(
                 OutgoingGamePacketType.MapSliceSouth,
@@ -411,16 +411,16 @@ namespace OpenTibia.Server.Notifications
             //       .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  ~  ---
             //
             // x = target start of window (~) to refresh.
-            var offset = new Location()
+            var windowStartLocation = new Location()
             {
                 // +9
-                X = IMap.DefaultWindowSizeX / 2,
+                X = this.Arguments.NewLocation.X + (IMap.DefaultWindowSizeX / 2),
 
                 // -6
-                Y = -((IMap.DefaultWindowSizeY / 2) - 1),
-            };
+                Y = this.Arguments.NewLocation.Y - ((IMap.DefaultWindowSizeY / 2) - 1),
 
-            var windowStartLocation = this.Arguments.NewLocation + offset;
+                Z = this.Arguments.NewLocation.Z,
+            };
 
             return new MapPartialDescriptionPacket(
                 OutgoingGamePacketType.MapSliceEast,
@@ -456,16 +456,18 @@ namespace OpenTibia.Server.Notifications
             //       ~  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  ---
             //
             // x = target start of window (~) to refresh.
-            var offset = new Location()
+            //
+            // We define the offset always from the old location, since it handles the edge case of moving diagonally.
+            var windowStartLocation = new Location()
             {
-                // -9
-                X = -(IMap.DefaultWindowSizeX / 2),
+                // -8
+                X = this.Arguments.NewLocation.X - ((IMap.DefaultWindowSizeX / 2) - 1),
 
                 // -6
-                Y = -((IMap.DefaultWindowSizeY / 2) - 1),
-            };
+                Y = this.Arguments.NewLocation.Y - ((IMap.DefaultWindowSizeY / 2) - 1),
 
-            var windowStartLocation = this.Arguments.OldLocation + offset;
+                Z = this.Arguments.NewLocation.Z,
+            };
 
             return new MapPartialDescriptionPacket(
                 OutgoingGamePacketType.MapSliceWest,

--- a/OpenTibia.Server/Notifications/WorldLightChangedNotification.cs
+++ b/OpenTibia.Server/Notifications/WorldLightChangedNotification.cs
@@ -1,0 +1,62 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="WorldLightChangedNotification.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Server.Notifications
+{
+    using System;
+    using System.Collections.Generic;
+    using OpenTibia.Common.Utilities;
+    using OpenTibia.Communications.Contracts.Abstractions;
+    using OpenTibia.Communications.Packets.Outgoing;
+    using Serilog;
+
+    /// <summary>
+    /// Class that represents a notification for a world light change.
+    /// </summary>
+    internal class WorldLightChangedNotification : Notification
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorldLightChangedNotification"/> class.
+        /// </summary>
+        /// <param name="logger">A reference to the logger in use.</param>
+        /// <param name="determineTargetConnectionsFunction">A function to determine the target connections of this notification.</param>
+        /// <param name="arguments">The arguments for this notification.</param>
+        public WorldLightChangedNotification(ILogger logger, Func<IEnumerable<IConnection>> determineTargetConnectionsFunction, WorldLightChangedNotificationArguments arguments)
+            : base(logger)
+        {
+            determineTargetConnectionsFunction.ThrowIfNull(nameof(determineTargetConnectionsFunction));
+            arguments.ThrowIfNull(nameof(arguments));
+
+            this.TargetConnectionsFunction = determineTargetConnectionsFunction;
+            this.Arguments = arguments;
+        }
+
+        /// <summary>
+        /// Gets this notification's arguments.
+        /// </summary>
+        public WorldLightChangedNotificationArguments Arguments { get; }
+
+        /// <summary>
+        /// Gets the function for determining target connections for this notification.
+        /// </summary>
+        protected override Func<IEnumerable<IConnection>> TargetConnectionsFunction { get; }
+
+        /// <summary>
+        /// Finalizes the notification in preparation to it being sent.
+        /// </summary>
+        /// <param name="playerId">The id of the player which this notification is being prepared for.</param>
+        /// <returns>A collection of <see cref="IOutgoingPacket"/>s, the ones to be sent.</returns>
+        protected override IEnumerable<IOutgoingPacket> Prepare(uint playerId)
+        {
+            return new WorldLightPacket(this.Arguments.LightLevel, this.Arguments.LightColor).YieldSingleItem();
+        }
+    }
+}

--- a/OpenTibia.Server/Notifications/WorldLightChangedNotificationArguments.cs
+++ b/OpenTibia.Server/Notifications/WorldLightChangedNotificationArguments.cs
@@ -1,0 +1,43 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="WorldLightChangedNotificationArguments.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Server.Notifications
+{
+    using OpenTibia.Server.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts.Enumerations;
+
+    /// <summary>
+    /// Class that represents arguments for the world light changed notification.
+    /// </summary>
+    internal class WorldLightChangedNotificationArguments : INotificationArguments
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorldLightChangedNotificationArguments"/> class.
+        /// </summary>
+        /// <param name="lightLevel">The new world light level.</param>
+        /// <param name="lightColor">The new world light color.</param>
+        public WorldLightChangedNotificationArguments(byte lightLevel, byte lightColor = (byte)LightColors.White)
+        {
+            this.LightLevel = lightLevel;
+            this.LightColor = lightColor;
+        }
+
+        /// <summary>
+        /// Gets the new world light level.
+        /// </summary>
+        public byte LightLevel { get; }
+
+        /// <summary>
+        /// Gets the new world light color.
+        /// </summary>
+        public byte LightColor { get; }
+    }
+}

--- a/OpenTibia.Server/Player.cs
+++ b/OpenTibia.Server/Player.cs
@@ -21,21 +21,24 @@ namespace OpenTibia.Server
 
     public class Player : Creature, IPlayer
     {
-        private const int KnownCreatureLimit = 100; // TODO: not sure of the number for this version... debugs will tell :|
+        /// <summary>
+        /// The limit of creatures that a player's client can keep track of.
+        /// </summary>
+        // TODO: not sure of the number for this version... debugs will tell :|
+        private const int KnownCreatureLimit = 100;
 
         private const sbyte MaxContainers = 16;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Player"/> class.
         /// </summary>
-        /// <param name="gameInstance"></param>
-        /// <param name="characterId"></param>
-        /// <param name="name"></param>
-        /// <param name="maxHitpoints"></param>
-        /// <param name="maxManapoints"></param>
-        /// <param name="corpse"></param>
-        /// <param name="hitpoints"></param>
-        /// <param name="manapoints"></param>
+        /// <param name="characterId">The id of the character that this player represents.</param>
+        /// <param name="name">The name of the player.</param>
+        /// <param name="maxHitpoints">The maximum number of hitpoints that the player starts with.</param>
+        /// <param name="maxManapoints">The maximum number of manapoints that the player starts with.</param>
+        /// <param name="corpse">The id of the corpse for the player.</param>
+        /// <param name="hitpoints">Optional. The number of hitpoints that the player starts with. Defaults to <paramref name="maxHitpoints"/>.</param>
+        /// <param name="manapoints">Optional. The number of manapoints that the player starts with. Defaults to <paramref name="maxManapoints"/>.</param>
         public Player(
             string characterId,
             string name,

--- a/OpenTibia.Server/SectorFileReader.cs
+++ b/OpenTibia.Server/SectorFileReader.cs
@@ -16,7 +16,6 @@ namespace OpenTibia.Server
     using System.IO;
     using System.Linq;
     using OpenTibia.Common.Utilities;
-    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Enumerations;
     using OpenTibia.Server.Contracts.Structs;
@@ -31,11 +30,11 @@ namespace OpenTibia.Server
 
         public const char PositionSeparator = '-';
 
-        public static IList<(Location, Tile)> ReadSector(ILogger logger, IItemFactory itemFactory, string fileName, string sectorFileContents, ushort xOffset, ushort yOffset, sbyte z)
+        public static IList<(Location, ITile)> ReadSector(ILogger logger, IItemFactory itemFactory, string fileName, string sectorFileContents, ushort xOffset, ushort yOffset, sbyte z)
         {
             itemFactory.ThrowIfNull(nameof(itemFactory));
 
-            var loadedTilesList = new List<(Location, Tile)>();
+            var loadedTilesList = new List<(Location, ITile)>();
 
             var lines = sectorFileContents.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 
@@ -67,7 +66,7 @@ namespace OpenTibia.Server
                 };
 
                 // start off with a tile that has no ground in it.
-                Tile newTile = new Tile(null);
+                ITile newTile = new Tile(null);
 
                 // load and add tile flags and contents.
                 foreach (var e in CipFileParser.Parse(tileData))

--- a/OpenTibia.Server/SectorFileReader.cs
+++ b/OpenTibia.Server/SectorFileReader.cs
@@ -12,11 +12,11 @@
 namespace OpenTibia.Server
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using OpenTibia.Common.Utilities;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Enumerations;
     using OpenTibia.Server.Contracts.Structs;
@@ -108,6 +108,8 @@ namespace OpenTibia.Server
                                     var thing = thingStack.Pop();
 
                                     newTile.AddThing(itemFactory, ref thing);
+
+                                    thing.Location = location;
                                 }
                             }
                         }

--- a/OpenTibia.Server/SectorMapLoader.cs
+++ b/OpenTibia.Server/SectorMapLoader.cs
@@ -121,8 +121,8 @@ namespace OpenTibia.Server
         /// <param name="toY">The end Y coordinate for the load window.</param>
         /// <param name="fromZ">The start Z coordinate for the load window.</param>
         /// <param name="toZ">The end Z coordinate for the load window.</param>
-        /// <returns>A collection of ordered pairs containing the <see cref="Location"/> and its corresponding <see cref="Tile"/>.</returns>
-        public IEnumerable<(Location Location, Tile Tile)> Load(int fromX, int toX, int fromY, int toY, sbyte fromZ, sbyte toZ)
+        /// <returns>A collection of ordered pairs containing the <see cref="Location"/> and its corresponding <see cref="ITile"/>.</returns>
+        public IEnumerable<(Location Location, ITile Tile)> Load(int fromX, int toX, int fromY, int toY, sbyte fromZ, sbyte toZ)
         {
             var fromSectorX = fromX / 32;
             var toSectorX = toX / 32;
@@ -134,7 +134,7 @@ namespace OpenTibia.Server
                 throw new InvalidOperationException("Bad range supplied.");
             }
 
-            var tuplesAdded = new List<(Location loc, Tile tile)>();
+            var tuplesAdded = new List<(Location loc, ITile tile)>();
 
             this.totalTileCount = ((toSectorX - fromSectorX + 1) * 32) * ((toSectorY - fromSectorY + 1) * 32) * (toZ - fromZ + 1);
             this.totalLoadedCount = default;

--- a/OpenTibia.Server/SectorMapLoader.cs
+++ b/OpenTibia.Server/SectorMapLoader.cs
@@ -18,6 +18,7 @@ namespace OpenTibia.Server
     using System.Threading.Tasks;
     using Microsoft.Extensions.Options;
     using OpenTibia.Common.Utilities;
+    using OpenTibia.Server.Contracts;
     using OpenTibia.Server.Contracts.Abstractions;
     using OpenTibia.Server.Contracts.Structs;
     using Serilog;

--- a/OpenTibia.Server/Tile.cs
+++ b/OpenTibia.Server/Tile.cs
@@ -9,7 +9,7 @@
 // </copyright>
 // -----------------------------------------------------------------
 
-namespace OpenTibia.Server.Contracts
+namespace OpenTibia.Server
 {
     using System;
     using System.Collections.Generic;


### PR DESCRIPTION
## Map slices description:
Fixed some bugs that made the client debug when moving around the map, in particular when the server sent map slices (north, south, east, west) of the new bytes in the description.

## Tile class decoupling:
Since Tile was changed to a class on the last PR, it needed to be decoupled from other classes. I extracted the ITile interface and decoupled the concrete implementation from everywhere else.

## Miscellaneous changes:
- Renamed ItemMove* handler and related to MoveThing* because it actually can be any thing moving on this request.
- Fixed a bunch of comments.
- Implemented a very basic movement events queue in the game, processed by the AdvanceTime thread, in preparation to streamline every game state change through these sort of processing loops (to keep everything consistent).

