### PR TITLE
Enable most move/use event rules due to almost complete implementation of the ScriptApi.

### DIFF
--- a/OpenTibia.Common.Utilities/BigInteger.cs
+++ b/OpenTibia.Common.Utilities/BigInteger.cs
@@ -1754,17 +1754,17 @@ namespace OpenTibia.Common.Utilities
             int pos = 0;
             uint tempVal, val = this.data[this.dataLength - 1];
 
-            if ((tempVal = val >> 24 & 0xFF) != 0)
+            if ((tempVal = (val >> 24) & 0xFF) != 0)
             {
                 result[pos++] = (byte)tempVal;
             }
 
-            if ((tempVal = val >> 16 & 0xFF) != 0)
+            if ((tempVal = (val >> 16) & 0xFF) != 0)
             {
                 result[pos++] = (byte)tempVal;
             }
 
-            if ((tempVal = val >> 8 & 0xFF) != 0)
+            if ((tempVal = (val >> 8) & 0xFF) != 0)
             {
                 result[pos++] = (byte)tempVal;
             }

--- a/OpenTibia.Communications.Handlers/ConfigurationRootExtensions.cs
+++ b/OpenTibia.Communications.Handlers/ConfigurationRootExtensions.cs
@@ -55,7 +55,7 @@ namespace OpenTibia.Communications.Handlers
             services.AddSingleton<IHandler, MoveThingHandler>();
             //services.AddSingleton<IHandler, ItemRotateHandler>();
             //services.AddSingleton<IHandler, ItemUseBattleHandler>();
-            services.AddSingleton<IHandler, ItemUseHandler>();
+            services.AddSingleton<IHandler, UseItemHandler>();
             //services.AddSingleton<IHandler, ItemUseOnHandler>();
             services.AddSingleton<IHandler, LogoutHandler>();
             services.AddSingleton<IHandler, LookAtHandler>();

--- a/OpenTibia.Communications.Handlers/Game/UseItemHandler.cs
+++ b/OpenTibia.Communications.Handlers/Game/UseItemHandler.cs
@@ -26,15 +26,15 @@ namespace OpenTibia.Communications.Handlers.Game
     /// <summary>
     /// Class that represents an item use handler for the game server.
     /// </summary>
-    public class ItemUseHandler : GameHandler
+    public class UseItemHandler : GameHandler
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ItemUseHandler"/> class.
+        /// Initializes a new instance of the <see cref="UseItemHandler"/> class.
         /// </summary>
         /// <param name="logger">A reference to the logger to use in this handler.</param>
         /// <param name="creatureFinder">A reference to the creature finder.</param>
         /// <param name="gameInstance">A reference to the game instance.</param>
-        public ItemUseHandler(
+        public UseItemHandler(
             ILogger logger,
             ICreatureFinder creatureFinder,
             IGame gameInstance)
@@ -42,7 +42,7 @@ namespace OpenTibia.Communications.Handlers.Game
         {
             creatureFinder.ThrowIfNull(nameof(creatureFinder));
 
-            this.Logger = logger.ForContext<ItemUseHandler>();
+            this.Logger = logger.ForContext<UseItemHandler>();
             this.CreatureFinder = creatureFinder;
         }
 

--- a/OpenTibia.Communications.Handlers/OpenTibia.Communications.Handlers.csproj
+++ b/OpenTibia.Communications.Handlers/OpenTibia.Communications.Handlers.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <Compile Include="Game\AutoMoveCancelHandler.cs" />
     <Compile Include="Game\AutoMoveHandler.cs" />
-    <Compile Include="Game\ItemUseHandler.cs" />
+    <Compile Include="Game\UseItemHandler.cs" />
     <Compile Include="Game\MoveThingHandler.cs" />
     <Compile Include="Game\LogoutHandler.cs" />
     <Compile Include="Game\LookAtHandler.cs" />

--- a/OpenTibia.Communications.Packets.Contracts/Abstractions/IItemUseInfo.cs
+++ b/OpenTibia.Communications.Packets.Contracts/Abstractions/IItemUseInfo.cs
@@ -16,7 +16,7 @@ namespace OpenTibia.Communications.Packets.Contracts.Abstractions
     /// <summary>
     /// Interface for an item use information.
     /// </summary>
-    public interface IItemUseInfo
+    public interface IUseItemInfo
     {
         /// <summary>
         /// Gets the location form which the item is being used.

--- a/OpenTibia.Communications.Packets/Incoming/UseItemPacket.cs
+++ b/OpenTibia.Communications.Packets/Incoming/UseItemPacket.cs
@@ -18,16 +18,16 @@ namespace OpenTibia.Communications.Packets.Incoming
     /// <summary>
     /// Class that represents a packet for an item use.
     /// </summary>
-    public class ItemUsePacket : IIncomingPacket, IItemUseInfo
+    public class UseItemPacket : IIncomingPacket, IUseItemInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ItemUsePacket"/> class.
+        /// Initializes a new instance of the <see cref="UseItemPacket"/> class.
         /// </summary>
         /// <param name="fromLocation">The location from which the item is being used.</param>
         /// <param name="clientId">The id of the item as seen by the client.</param>
         /// <param name="fromStackPos">The position in the stack from which the item is being used.</param>
         /// <param name="index">The index of the item being used.</param>
-        public ItemUsePacket(Location fromLocation, ushort clientId, byte fromStackPos, byte index)
+        public UseItemPacket(Location fromLocation, ushort clientId, byte fromStackPos, byte index)
         {
             this.ItemClientId = clientId;
 

--- a/OpenTibia.Communications.Packets/NetworkMessagePacketExtensions.cs
+++ b/OpenTibia.Communications.Packets/NetworkMessagePacketExtensions.cs
@@ -241,9 +241,9 @@ namespace OpenTibia.Communications.Packets
         /// </summary>
         /// <param name="message">The mesage to read the information from.</param>
         /// <returns>The item use information.</returns>
-        public static IItemUseInfo ReadItemUseInfo(this INetworkMessage message)
+        public static IUseItemInfo ReadItemUseInfo(this INetworkMessage message)
         {
-            return new ItemUsePacket(
+            return new UseItemPacket(
                 fromLocation: new Location
                 {
                     X = message.GetUInt16(),

--- a/OpenTibia.Security/Encryption/Xtea.cs
+++ b/OpenTibia.Security/Encryption/Xtea.cs
@@ -52,11 +52,11 @@ namespace OpenTibia.Security.Encryption
 
                     while (xCount-- > 0)
                     {
-                        words[pos] += (words[pos + 1] << 4 ^ words[pos + 1] >> 5) + words[pos + 1] ^ xSum + key[xSum & 3];
+                        words[pos] += (((words[pos + 1] << 4) ^ (words[pos + 1] >> 5)) + words[pos + 1]) ^ (xSum + key[xSum & 3]);
 
                         xSum += xDelta;
 
-                        words[pos + 1] += (words[pos] << 4 ^ words[pos] >> 5) + words[pos] ^ xSum + key[xSum >> 11 & 3];
+                        words[pos + 1] += (((words[pos] << 4) ^ (words[pos] >> 5)) + words[pos]) ^ (xSum + key[(xSum >> 11) & 3]);
                     }
                 }
             }
@@ -90,11 +90,11 @@ namespace OpenTibia.Security.Encryption
 
                     while (xCount-- > 0)
                     {
-                        words[pos + 1] -= (words[pos] << 4 ^ words[pos] >> 5) + words[pos] ^ xSum + key[xSum >> 11 & 3];
+                        words[pos + 1] -= (((words[pos] << 4) ^ (words[pos] >> 5)) + words[pos]) ^ (xSum + key[(xSum >> 11) & 3]);
 
                         xSum -= xDelta;
 
-                        words[pos] -= (words[pos + 1] << 4 ^ words[pos + 1] >> 5) + words[pos + 1] ^ xSum + key[xSum & 3];
+                        words[pos] -= (((words[pos + 1] << 4) ^ (words[pos + 1] >> 5)) + words[pos + 1]) ^ (xSum + key[xSum & 3]);
                     }
                 }
             }

--- a/OpenTibia.Server.Contracts/Abstractions/IGame.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/IGame.cs
@@ -175,6 +175,39 @@ namespace OpenTibia.Server.Contracts.Abstractions
         bool PerformItemUse(ushort itemId, Location fromLocation, byte fromStackPos, byte index, ICreature requestor = null);
 
         /// <summary>
+        /// Inmediately attempts to perform an item creation in behalf of the requesting creature, if any.
+        /// </summary>
+        /// <param name="typeId">The id of the item being being created.</param>
+        /// <param name="atLocation">The location at which the item is being created.</param>
+        /// <param name="requestor">Optional. The creature requesting the creation.</param>
+        /// <returns>True if the item was successfully created, false otherwise.</returns>
+        /// <remarks>Changes game state, should only be performed after all pertinent validations happen.</remarks>>
+        bool PerformItemCreation(ushort typeId, Location atLocation, ICreature requestor);
+
+        /// <summary>
+        /// Inmediately attempts to perform an item deletion in behalf of the requesting creature, if any.
+        /// </summary>
+        /// <param name="typeId">The id of the item being being deleted.</param>
+        /// <param name="atLocation">The location at which the item is being deleted.</param>
+        /// <param name="requestor">Optional. The creature requesting the deletion.</param>
+        /// <returns>True if the item was successfully deleted, false otherwise.</returns>
+        /// <remarks>Changes game state, should only be performed after all pertinent validations happen.</remarks>
+        bool PerformItemDeletion(ushort typeId, Location atLocation, ICreature requestor);
+
+        /// <summary>
+        /// Inmediately attempts to perform an item change in behalf of the requesting creature, if any.
+        /// </summary>
+        /// <param name="fromTypeId">The type id of the item being changed.</param>
+        /// <param name="toTypeId">The type id of the item being changed to.</param>
+        /// <param name="fromLocation">The location from which the changed is happening.</param>
+        /// <param name="fromStackPos">The position in the stack of the item at the location.</param>
+        /// <param name="index">The index of the item to changed.</param>
+        /// <param name="requestor">Optional. The creature requesting the use.</param>
+        /// <returns>True if the item was successfully changed, false otherwise.</returns>
+        /// <remarks>Changes game state, should only be performed after all pertinent validations happen.</remarks>
+        bool PerformItemChange(ushort fromTypeId, ushort toTypeId, Location fromLocation, byte fromStackPos, byte index, ICreature requestor = null);
+
+        /// <summary>
         /// Evaluates separation event rules on the given location for the given thing, on behalf of the supplied requestor creature.
         /// </summary>
         /// <param name="fromLocation">The location from which the events take place.</param>
@@ -256,8 +289,9 @@ namespace OpenTibia.Server.Contracts.Abstractions
         /// </summary>
         /// <param name="fromLocation">The location from which to move everything.</param>
         /// <param name="targetLocation">The location to move everything to.</param>
+        /// <param name="exceptTypeIds">Optional. Any type ids to explicitly exclude.</param>
         /// <returns>True if the request was accepted, false otherwise.</returns>
-        bool ScriptRequest_MoveEverythingTo(Location fromLocation, Location targetLocation);
+        bool ScriptRequest_MoveEverythingTo(Location fromLocation, Location targetLocation, params ushort[] exceptTypeIds);
 
         /// <summary>
         /// Attempts to move an item to a given location.
@@ -274,7 +308,7 @@ namespace OpenTibia.Server.Contracts.Abstractions
         /// <param name="fromLocation">The location from which to move the item.</param>
         /// <param name="toLocation">The location to which to move the item.</param>
         /// <returns>True if the request was accepted, false otherwise.</returns>
-        bool ScriptRequest_MoveItemByIdTo(ushort itemType, Location fromLocation, Location toLocation);
+        bool ScriptRequest_MoveItemOfTypeTo(ushort itemType, Location fromLocation, Location toLocation);
 
         /// <summary>
         /// Attempts to log out a player.

--- a/OpenTibia.Server.Contracts/Abstractions/IScriptApi.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/IScriptApi.cs
@@ -65,7 +65,7 @@ namespace OpenTibia.Server.Contracts.Abstractions
 
         void MoveThingTo(IThing thingToMove, Location targetLocation);
 
-        void MoveEverythingToLocation(Location fromLocation, Location targetLocation);
+        void MoveEverythingToLocation(Location fromLocation, Location targetLocation, params ushort[] exceptTypeIds);
 
         void MoveByIdToLocation(ushort itemId, Location fromLocation, Location toLocation);
 

--- a/OpenTibia.Server.Contracts/Abstractions/ITile.cs
+++ b/OpenTibia.Server.Contracts/Abstractions/ITile.cs
@@ -45,7 +45,9 @@ namespace OpenTibia.Server.Contracts.Abstractions
 
         bool RemoveThing(IItemFactory itemFactory, ref IThing thing, byte count = 1);
 
-        bool HasItemWithId(ushort itemId);
+        bool HasItemWithId(ushort typeId);
+
+        IItem FindItemWithId(ushort typeId);
 
         byte GetStackPositionOfThing(IThing thing);
 

--- a/OpenTibia.Server.Events.MoveUseFile/MoveUseScriptApiAdapter.cs
+++ b/OpenTibia.Server.Events.MoveUseFile/MoveUseScriptApiAdapter.cs
@@ -480,14 +480,14 @@ namespace OpenTibia.Server.Events.MoveUseFile
         }
 
         /// <summary>
-        /// Moves any amount of items of a given type from one location to another.
+        /// Moves any amount of items except a given ground type from one location to another.
         /// </summary>
         /// <param name="fromLocation">The location from which to move.</param>
-        /// <param name="typeId">The item type to move.</param>
+        /// <param name="typeId">The item type to ignore when moving.</param>
         /// <param name="toLocation">The location to move to.</param>
         public void MoveTopOnMap(Location fromLocation, ushort typeId, Location toLocation)
         {
-            this.ScriptApi.MoveByIdToLocation(typeId, fromLocation, toLocation);
+            this.ScriptApi.MoveEverythingToLocation(fromLocation, toLocation, typeId);
         }
 
         /// <summary>

--- a/OpenTibia.Server.Map.SectorFiles/SectorMapLoader.cs
+++ b/OpenTibia.Server.Map.SectorFiles/SectorMapLoader.cs
@@ -105,7 +105,7 @@ namespace OpenTibia.Server.Map.SectorFiles
         {
             if (x > SectorXMax)
             {
-                return this.sectorsLoaded[x / 32 - SectorXMin, y / 32 - SectorYMin, z - SectorZMin];
+                return this.sectorsLoaded[(x / 32) - SectorXMin, (y / 32) - SectorYMin, z - SectorZMin];
             }
 
             return this.sectorsLoaded[x - SectorXMin, y - SectorYMin, z - SectorZMin];

--- a/OpenTibia.Server/ChangeItemEvent.cs
+++ b/OpenTibia.Server/ChangeItemEvent.cs
@@ -1,0 +1,147 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="ChangeItemEvent.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Server.MovementEvents
+{
+    using System.Collections.Generic;
+    using OpenTibia.Common.Utilities;
+    using OpenTibia.Communications.Contracts.Abstractions;
+    using OpenTibia.Communications.Packets.Outgoing;
+    using OpenTibia.Scheduling;
+    using OpenTibia.Scheduling.Contracts.Enumerations;
+    using OpenTibia.Server;
+    using OpenTibia.Server.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts.Enumerations;
+    using OpenTibia.Server.Contracts.Structs;
+    using OpenTibia.Server.Notifications;
+    using Serilog;
+
+    /// <summary>
+    /// Class that represents an event for an item change.
+    /// </summary>
+    public class ChangeItemEvent : BaseEvent
+    {
+        /// <summary>
+        /// Caches the requestor creature, if defined.
+        /// </summary>
+        private ICreature requestor = null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeItemEvent"/> class.
+        /// </summary>
+        /// <param name="logger">A reference to the logger in use.</param>
+        /// <param name="game">A reference to the game instance.</param>
+        /// <param name="connectionManager">A reference to the connection manager in use.</param>
+        /// <param name="tileAccessor">A reference to the tile accessor in use.</param>
+        /// <param name="creatureFinder">A reference to the creature finder in use.</param>
+        /// <param name="requestorId">The id of the creature requesting the use.</param>
+        /// <param name="typeId">The type id of the item being used.</param>
+        /// <param name="fromLocation">The location from which the item is being used.</param>
+        /// <param name="toTypeId">The type id of the item to change to.</param>
+        /// <param name="fromStackPos">The position in the stack from which the item is being used.</param>
+        /// <param name="index">The index of the item being used.</param>
+        /// <param name="evaluationTime">The time to evaluate the movement.</param>
+        public ChangeItemEvent(
+            ILogger logger,
+            IGame game,
+            IConnectionManager connectionManager,
+            ITileAccessor tileAccessor,
+            ICreatureFinder creatureFinder,
+            uint requestorId,
+            ushort typeId,
+            Location fromLocation,
+            ushort toTypeId,
+            byte fromStackPos = byte.MaxValue,
+            byte index = 1,
+            EvaluationTime evaluationTime = EvaluationTime.OnBoth)
+            : base(logger, requestorId, evaluationTime)
+        {
+            game.ThrowIfNull(nameof(game));
+            tileAccessor.ThrowIfNull(nameof(tileAccessor));
+            connectionManager.ThrowIfNull(nameof(connectionManager));
+            creatureFinder.ThrowIfNull(nameof(creatureFinder));
+
+            this.ConnectionManager = connectionManager;
+            this.CreatureFinder = creatureFinder;
+            this.Game = game;
+
+            this.ActionsOnFail.Add(new GenericEventAction(this.NotifyOfFailure));
+
+            var onPassAction = new GenericEventAction(() =>
+            {
+                bool successfulUse = this.Game.PerformItemChange(typeId, toTypeId, fromLocation, fromStackPos, index, this.Requestor);
+
+                if (!successfulUse)
+                {
+                    // handles check for isPlayer.
+                    this.NotifyOfFailure();
+
+                    return;
+                }
+            });
+
+            this.ActionsOnPass.Add(onPassAction);
+        }
+
+        /// <summary>
+        /// Gets the connection manager in use.
+        /// </summary>
+        public IConnectionManager ConnectionManager { get; }
+
+        /// <summary>
+        /// Gets the creature finder instance in use.
+        /// </summary>
+        public ICreatureFinder CreatureFinder { get; }
+
+        /// <summary>
+        /// Gets a reference to the game instance.
+        /// </summary>
+        public IGame Game { get; }
+
+        /// <summary>
+        /// Gets the creature that is requesting the event, if known.
+        /// </summary>
+        public ICreature Requestor
+        {
+            get
+            {
+                if (this.RequestorId > 0 && this.requestor == null)
+                {
+                    this.requestor = this.CreatureFinder.FindCreatureById(this.RequestorId);
+                }
+
+                return this.requestor;
+            }
+        }
+
+        /// <summary>
+        /// Notifies the requestor player, if any,of this failure.
+        /// </summary>
+        protected void NotifyOfFailure()
+        {
+            if (this.Requestor is Player player)
+            {
+                IEnumerable<IConnection> FindPlayerConnectionFunc()
+                {
+                    return this.ConnectionManager.FindByPlayerId(player.Id).YieldSingleItem();
+                }
+
+                var notificationArgs = new GenericNotificationArguments(
+                            new PlayerWalkCancelPacket(player.Direction),
+                            new TextMessagePacket(MessageType.StatusSmall, this.ErrorMessage ?? "Sorry, not possible."));
+
+                var notification = new GenericNotification(this.Logger, FindPlayerConnectionFunc, notificationArgs);
+
+                this.Game.RequestNofitication(notification);
+            }
+        }
+    }
+}

--- a/OpenTibia.Server/CreateItemEvent.cs
+++ b/OpenTibia.Server/CreateItemEvent.cs
@@ -1,0 +1,141 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="CreateItemEvent.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Server.MovementEvents
+{
+    using System.Collections.Generic;
+    using OpenTibia.Common.Utilities;
+    using OpenTibia.Communications.Contracts.Abstractions;
+    using OpenTibia.Communications.Packets.Outgoing;
+    using OpenTibia.Scheduling;
+    using OpenTibia.Scheduling.Contracts.Enumerations;
+    using OpenTibia.Server;
+    using OpenTibia.Server.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts.Enumerations;
+    using OpenTibia.Server.Contracts.Structs;
+    using OpenTibia.Server.Notifications;
+    using Serilog;
+
+    /// <summary>
+    /// Class that represents an event for an item creation.
+    /// </summary>
+    public class CreateItemEvent : BaseEvent
+    {
+        /// <summary>
+        /// Caches the requestor creature, if defined.
+        /// </summary>
+        private ICreature requestor = null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateItemEvent"/> class.
+        /// </summary>
+        /// <param name="logger">A reference to the logger in use.</param>
+        /// <param name="game">A reference to the game instance.</param>
+        /// <param name="connectionManager">A reference to the connection manager in use.</param>
+        /// <param name="tileAccessor">A reference to the tile accessor in use.</param>
+        /// <param name="creatureFinder">A reference to the creature finder in use.</param>
+        /// <param name="requestorId">The id of the creature requesting the use.</param>
+        /// <param name="typeId">The type id of the item being created.</param>
+        /// <param name="atLocation">The location from which the item is being created.</param>
+        /// <param name="evaluationTime">The time to evaluate the movement.</param>
+        public CreateItemEvent(
+            ILogger logger,
+            IGame game,
+            IConnectionManager connectionManager,
+            ITileAccessor tileAccessor,
+            ICreatureFinder creatureFinder,
+            uint requestorId,
+            ushort typeId,
+            Location atLocation,
+            EvaluationTime evaluationTime = EvaluationTime.OnBoth)
+            : base(logger, requestorId, evaluationTime)
+        {
+            game.ThrowIfNull(nameof(game));
+            tileAccessor.ThrowIfNull(nameof(tileAccessor));
+            connectionManager.ThrowIfNull(nameof(connectionManager));
+            creatureFinder.ThrowIfNull(nameof(creatureFinder));
+
+            this.ConnectionManager = connectionManager;
+            this.CreatureFinder = creatureFinder;
+            this.Game = game;
+
+            this.ActionsOnFail.Add(new GenericEventAction(this.NotifyOfFailure));
+
+            var onPassAction = new GenericEventAction(() =>
+            {
+                bool successfulCreation = this.Game.PerformItemCreation(typeId, atLocation, this.Requestor);
+
+                if (!successfulCreation)
+                {
+                    // handles check for isPlayer.
+                    this.NotifyOfFailure();
+
+                    return;
+                }
+            });
+
+            this.ActionsOnPass.Add(onPassAction);
+        }
+
+        /// <summary>
+        /// Gets the connection manager in use.
+        /// </summary>
+        public IConnectionManager ConnectionManager { get; }
+
+        /// <summary>
+        /// Gets the creature finder instance in use.
+        /// </summary>
+        public ICreatureFinder CreatureFinder { get; }
+
+        /// <summary>
+        /// Gets a reference to the game instance.
+        /// </summary>
+        public IGame Game { get; }
+
+        /// <summary>
+        /// Gets the creature that is requesting the event, if known.
+        /// </summary>
+        public ICreature Requestor
+        {
+            get
+            {
+                if (this.RequestorId > 0 && this.requestor == null)
+                {
+                    this.requestor = this.CreatureFinder.FindCreatureById(this.RequestorId);
+                }
+
+                return this.requestor;
+            }
+        }
+
+        /// <summary>
+        /// Notifies the requestor player, if any,of this failure.
+        /// </summary>
+        protected void NotifyOfFailure()
+        {
+            if (this.Requestor is Player player)
+            {
+                IEnumerable<IConnection> FindPlayerConnectionFunc()
+                {
+                    return this.ConnectionManager.FindByPlayerId(player.Id).YieldSingleItem();
+                }
+
+                var notificationArgs = new GenericNotificationArguments(
+                            new PlayerWalkCancelPacket(player.Direction),
+                            new TextMessagePacket(MessageType.StatusSmall, this.ErrorMessage ?? "Sorry, not possible."));
+
+                var notification = new GenericNotification(this.Logger, FindPlayerConnectionFunc, notificationArgs);
+
+                this.Game.RequestNofitication(notification);
+            }
+        }
+    }
+}

--- a/OpenTibia.Server/DeleteItemEvent.cs
+++ b/OpenTibia.Server/DeleteItemEvent.cs
@@ -42,10 +42,10 @@ namespace OpenTibia.Server.MovementEvents
         /// <param name="connectionManager">A reference to the connection manager in use.</param>
         /// <param name="tileAccessor">A reference to the tile accessor in use.</param>
         /// <param name="creatureFinder">A reference to the creature finder in use.</param>
-        /// <param name="requestorId">The id of the creature requesting the use.</param>
-        /// <param name="typeId">The type id of the item being created.</param>
-        /// <param name="atLocation">The location from which the item is being created.</param>
-        /// <param name="evaluationTime">The time to evaluate the movement.</param>
+        /// <param name="requestorId">The id of the creature requesting the deletion.</param>
+        /// <param name="typeId">The type id of the item being deleted.</param>
+        /// <param name="atLocation">The location from which the item is being deleted.</param>
+        /// <param name="evaluationTime">The time to evaluate the event.</param>
         public DeleteItemEvent(
             ILogger logger,
             IGame game,

--- a/OpenTibia.Server/DeleteItemEvent.cs
+++ b/OpenTibia.Server/DeleteItemEvent.cs
@@ -1,0 +1,141 @@
+﻿// -----------------------------------------------------------------
+// <copyright file="DeleteItemEvent.cs" company="2Dudes">
+// Copyright (c) 2018 2Dudes. All rights reserved.
+// Author: Jose L. Nunez de Caceres
+// http://linkedin.com/in/jlnunez89
+//
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------
+
+namespace OpenTibia.Server.MovementEvents
+{
+    using System.Collections.Generic;
+    using OpenTibia.Common.Utilities;
+    using OpenTibia.Communications.Contracts.Abstractions;
+    using OpenTibia.Communications.Packets.Outgoing;
+    using OpenTibia.Scheduling;
+    using OpenTibia.Scheduling.Contracts.Enumerations;
+    using OpenTibia.Server;
+    using OpenTibia.Server.Contracts.Abstractions;
+    using OpenTibia.Server.Contracts.Enumerations;
+    using OpenTibia.Server.Contracts.Structs;
+    using OpenTibia.Server.Notifications;
+    using Serilog;
+
+    /// <summary>
+    /// Class that represents an event for an item deletion.
+    /// </summary>
+    public class DeleteItemEvent : BaseEvent
+    {
+        /// <summary>
+        /// Caches the requestor creature, if defined.
+        /// </summary>
+        private ICreature requestor = null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteItemEvent"/> class.
+        /// </summary>
+        /// <param name="logger">A reference to the logger in use.</param>
+        /// <param name="game">A reference to the game instance.</param>
+        /// <param name="connectionManager">A reference to the connection manager in use.</param>
+        /// <param name="tileAccessor">A reference to the tile accessor in use.</param>
+        /// <param name="creatureFinder">A reference to the creature finder in use.</param>
+        /// <param name="requestorId">The id of the creature requesting the use.</param>
+        /// <param name="typeId">The type id of the item being created.</param>
+        /// <param name="atLocation">The location from which the item is being created.</param>
+        /// <param name="evaluationTime">The time to evaluate the movement.</param>
+        public DeleteItemEvent(
+            ILogger logger,
+            IGame game,
+            IConnectionManager connectionManager,
+            ITileAccessor tileAccessor,
+            ICreatureFinder creatureFinder,
+            uint requestorId,
+            ushort typeId,
+            Location atLocation,
+            EvaluationTime evaluationTime = EvaluationTime.OnBoth)
+            : base(logger, requestorId, evaluationTime)
+        {
+            game.ThrowIfNull(nameof(game));
+            tileAccessor.ThrowIfNull(nameof(tileAccessor));
+            connectionManager.ThrowIfNull(nameof(connectionManager));
+            creatureFinder.ThrowIfNull(nameof(creatureFinder));
+
+            this.ConnectionManager = connectionManager;
+            this.CreatureFinder = creatureFinder;
+            this.Game = game;
+
+            this.ActionsOnFail.Add(new GenericEventAction(this.NotifyOfFailure));
+
+            var onPassAction = new GenericEventAction(() =>
+            {
+                bool successfulCreation = this.Game.PerformItemDeletion(typeId, atLocation, this.Requestor);
+
+                if (!successfulCreation)
+                {
+                    // handles check for isPlayer.
+                    this.NotifyOfFailure();
+
+                    return;
+                }
+            });
+
+            this.ActionsOnPass.Add(onPassAction);
+        }
+
+        /// <summary>
+        /// Gets the connection manager in use.
+        /// </summary>
+        public IConnectionManager ConnectionManager { get; }
+
+        /// <summary>
+        /// Gets the creature finder instance in use.
+        /// </summary>
+        public ICreatureFinder CreatureFinder { get; }
+
+        /// <summary>
+        /// Gets a reference to the game instance.
+        /// </summary>
+        public IGame Game { get; }
+
+        /// <summary>
+        /// Gets the creature that is requesting the event, if known.
+        /// </summary>
+        public ICreature Requestor
+        {
+            get
+            {
+                if (this.RequestorId > 0 && this.requestor == null)
+                {
+                    this.requestor = this.CreatureFinder.FindCreatureById(this.RequestorId);
+                }
+
+                return this.requestor;
+            }
+        }
+
+        /// <summary>
+        /// Notifies the requestor player, if any,of this failure.
+        /// </summary>
+        protected void NotifyOfFailure()
+        {
+            if (this.Requestor is Player player)
+            {
+                IEnumerable<IConnection> FindPlayerConnectionFunc()
+                {
+                    return this.ConnectionManager.FindByPlayerId(player.Id).YieldSingleItem();
+                }
+
+                var notificationArgs = new GenericNotificationArguments(
+                            new PlayerWalkCancelPacket(player.Direction),
+                            new TextMessagePacket(MessageType.StatusSmall, this.ErrorMessage ?? "Sorry, not possible."));
+
+                var notification = new GenericNotification(this.Logger, FindPlayerConnectionFunc, notificationArgs);
+
+                this.Game.RequestNofitication(notification);
+            }
+        }
+    }
+}

--- a/OpenTibia.Server/Notifications/CreatureMovedNotification.cs
+++ b/OpenTibia.Server/Notifications/CreatureMovedNotification.cs
@@ -147,7 +147,12 @@ namespace OpenTibia.Server.Notifications
                     packets.Add(new MapPartialDescriptionPacket(OutgoingGamePacketType.FloorChangeDown, description));
 
                     // moving down a floor makes us out of sync, include east and south
-                    packets.Add(this.EastSliceDescription(player, this.Arguments.OldLocation.Z - this.Arguments.NewLocation.Z + this.Arguments.OldLocation.Y - this.Arguments.NewLocation.Y));
+                    packets.Add(
+                        this.EastSliceDescription(
+                            player,
+                            this.Arguments.OldLocation.X - this.Arguments.NewLocation.X,
+                            this.Arguments.OldLocation.Y - this.Arguments.NewLocation.Y + this.Arguments.OldLocation.Z - this.Arguments.NewLocation.Z));
+
                     packets.Add(this.SouthSliceDescription(player, this.Arguments.OldLocation.Y - this.Arguments.NewLocation.Y));
                 }
 
@@ -186,7 +191,12 @@ namespace OpenTibia.Server.Notifications
                     packets.Add(new MapPartialDescriptionPacket(OutgoingGamePacketType.FloorChangeUp, description));
 
                     // moving up a floor up makes us out of sync, include west and north
-                    packets.Add(this.WestSliceDescription(player, this.Arguments.OldLocation.Z - this.Arguments.NewLocation.Z + this.Arguments.OldLocation.Y - this.Arguments.NewLocation.Y));
+                    packets.Add(
+                        this.WestSliceDescription(
+                            player,
+                            this.Arguments.OldLocation.X - this.Arguments.NewLocation.X,
+                            this.Arguments.OldLocation.Y - this.Arguments.NewLocation.Y + this.Arguments.OldLocation.Z - this.Arguments.NewLocation.Z));
+
                     packets.Add(this.NorthSliceDescription(player, this.Arguments.OldLocation.Y - this.Arguments.NewLocation.Y));
                 }
 
@@ -343,7 +353,7 @@ namespace OpenTibia.Server.Notifications
                     1));
         }
 
-        private IOutgoingPacket EastSliceDescription(IPlayer player, int floorChangeOffset = 0)
+        private IOutgoingPacket EastSliceDescription(IPlayer player, int floorChangeOffsetX = 0, int floorChangeOffsetY = 0)
         {
             // A = old location, B = new location
             //
@@ -368,10 +378,10 @@ namespace OpenTibia.Server.Notifications
             var windowStartLocation = new Location()
             {
                 // +9
-                X = this.Arguments.NewLocation.X + (IMap.DefaultWindowSizeX / 2),
+                X = this.Arguments.NewLocation.X + (IMap.DefaultWindowSizeX / 2) + floorChangeOffsetX,
 
                 // -6
-                Y = this.Arguments.NewLocation.Y - ((IMap.DefaultWindowSizeY / 2) - 1) + floorChangeOffset,
+                Y = this.Arguments.NewLocation.Y - ((IMap.DefaultWindowSizeY / 2) - 1) + floorChangeOffsetY,
 
                 Z = this.Arguments.NewLocation.Z,
             };
@@ -388,7 +398,7 @@ namespace OpenTibia.Server.Notifications
                     IMap.DefaultWindowSizeY));
         }
 
-        private IOutgoingPacket WestSliceDescription(IPlayer player, int floorChangeOffset = 0)
+        private IOutgoingPacket WestSliceDescription(IPlayer player, int floorChangeOffsetX = 0, int floorChangeOffsetY = 0)
         {
             // A = old location, B = new location
             //
@@ -413,10 +423,10 @@ namespace OpenTibia.Server.Notifications
             var windowStartLocation = new Location()
             {
                 // -8
-                X = this.Arguments.NewLocation.X - ((IMap.DefaultWindowSizeX / 2) - 1),
+                X = this.Arguments.NewLocation.X - ((IMap.DefaultWindowSizeX / 2) - 1) + floorChangeOffsetX,
 
                 // -6
-                Y = this.Arguments.NewLocation.Y - ((IMap.DefaultWindowSizeY / 2) - 1) + floorChangeOffset,
+                Y = this.Arguments.NewLocation.Y - ((IMap.DefaultWindowSizeY / 2) - 1) + floorChangeOffsetY,
 
                 Z = this.Arguments.NewLocation.Z,
             };

--- a/OpenTibia.Server/StandardScriptApi.cs
+++ b/OpenTibia.Server/StandardScriptApi.cs
@@ -283,14 +283,14 @@ namespace OpenTibia.Server.Factories
             }
         }
 
-        public void MoveEverythingToLocation(Location fromLocation, Location targetLocation)
+        public void MoveEverythingToLocation(Location fromLocation, Location targetLocation, params ushort[] exceptTypeIds)
         {
-            this.Game.ScriptRequest_MoveEverythingTo(fromLocation, targetLocation);
+            this.Game.ScriptRequest_MoveEverythingTo(fromLocation, targetLocation, exceptTypeIds);
         }
 
         public void MoveByIdToLocation(ushort itemId, Location fromLocation, Location toLocation)
         {
-            this.Game.ScriptRequest_MoveItemByIdTo(itemId, fromLocation, toLocation);
+            this.Game.ScriptRequest_MoveItemOfTypeTo(itemId, fromLocation, toLocation);
         }
 
         public void DisplayAnimatedText(Location location, string text, byte textType)


### PR DESCRIPTION
## Miscellaneous changes:
- Renamed _ItemUseHandler_ to _UseItemHandler_, along with all related classes. Just makes more sense.
- **Bugfix**: set item location when it's added to a Tile. This was preventing separation event rules to run correctly.
- Fixed map partial description bugs for changing floors by using items from all angles, i.e. ladders and trapdoors.

## Script API implementation
Most of the API is implemented now. Just to list some of the changes, I added:
- Moving things (map only)
- Changing things (map only)
- Creating items.
- Deleting items.
