### PR TITLE
Fix bottom floors map description bug.

### DIFF
--- a/OpenTibia.Communications.Packets/Outgoing/SelfAppearPacket.cs
+++ b/OpenTibia.Communications.Packets/Outgoing/SelfAppearPacket.cs
@@ -64,8 +64,6 @@ namespace OpenTibia.Communications.Packets.Outgoing
         /// </summary>
         public IPlayer Player { get; }
 
-        // public HashSet<string> Privileges { get; }
-
         /// <summary>
         /// Writes the packet to the message provided.
         /// </summary>

--- a/OpenTibia.Server/Game.cs
+++ b/OpenTibia.Server/Game.cs
@@ -40,6 +40,8 @@ namespace OpenTibia.Server
 
         public static Location VeteranStart = new Location { X = 32369, Y = 32241, Z = 7 };
 
+        public static Location HellsGate = new Location { X = 32675, Y = 31648, Z = 10 };
+
         /// <summary>
         /// Default delay for scripts.
         /// </summary>
@@ -85,7 +87,7 @@ namespace OpenTibia.Server
         /// <param name="eventRulesLoader">A reference to the event rules loader.</param>
         /// <param name="itemFactory">A reference to the item factory in use.</param>
         /// <param name="creatureFactory">A reference to the creature factory in use.</param>
-        /// <param name="scriptApi"></param>
+        /// <param name="scriptApi">A reference to the script api in use.</param>
         public Game(
             ILogger logger,
             IMap map,
@@ -251,7 +253,7 @@ namespace OpenTibia.Server
             // playerRecord.location
             IThing playerThing = player;
 
-            playerThing.Location = Game.VeteranStart;
+            playerThing.Location = Game.HellsGate;
 
             if (this.map.GetTileAt(player.Location, out ITile targetTile))
             {

--- a/OpenTibia.Server/Notifications/CreatureMovedNotification.cs
+++ b/OpenTibia.Server/Notifications/CreatureMovedNotification.cs
@@ -132,7 +132,7 @@ namespace OpenTibia.Server.Notifications
                     }
 
                     // going further down underground; watch for world's deepest floor (hardcoded for now).
-                    else if (this.Arguments.NewLocation.Z > this.Arguments.OldLocation.Z && this.Arguments.NewLocation.Z > 8 && this.Arguments.NewLocation.Z < 14)
+                    else if (this.Arguments.NewLocation.Z > 8 && this.Arguments.NewLocation.Z < 14)
                     {
                         // Client already has all floors needed except the new deepest floor, so it needs the 2th floor below the current.
                         description = this.Game.GetDescriptionOfMapForPlayer(player, (ushort)windowStartLocation.X, (ushort)windowStartLocation.Y, (sbyte)(this.Arguments.NewLocation.Z + 2), (sbyte)(this.Arguments.NewLocation.Z + 2), IMap.DefaultWindowSizeX, IMap.DefaultWindowSizeY, -3);
@@ -301,8 +301,8 @@ namespace OpenTibia.Server.Notifications
                     player,
                     (ushort)windowStartLocation.X,
                     (ushort)windowStartLocation.Y,
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z - 2 : 7),
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z + 2 : 0),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Max(0, this.Arguments.NewLocation.Z - 2) : 7),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Min(15, this.Arguments.NewLocation.Z + 2) : 0),
                     IMap.DefaultWindowSizeX,
                     1));
         }
@@ -347,8 +347,8 @@ namespace OpenTibia.Server.Notifications
                     player,
                     (ushort)windowStartLocation.X,
                     (ushort)windowStartLocation.Y,
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z - 2 : 7),
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z + 2 : 0),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Max(0, this.Arguments.NewLocation.Z - 2) : 7),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Min(15, this.Arguments.NewLocation.Z + 2) : 0),
                     IMap.DefaultWindowSizeX,
                     1));
         }
@@ -392,8 +392,8 @@ namespace OpenTibia.Server.Notifications
                     player,
                     (ushort)windowStartLocation.X,
                     (ushort)windowStartLocation.Y,
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z - 2 : 7),
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z + 2 : 0),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Max(0, this.Arguments.NewLocation.Z - 2) : 7),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Min(15, this.Arguments.NewLocation.Z + 2) : 0),
                     1,
                     IMap.DefaultWindowSizeY));
         }
@@ -437,8 +437,8 @@ namespace OpenTibia.Server.Notifications
                     player,
                     (ushort)windowStartLocation.X,
                     (ushort)windowStartLocation.Y,
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z - 2 : 7),
-                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? this.Arguments.NewLocation.Z + 2 : 0),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Max(0, this.Arguments.NewLocation.Z - 2) : 7),
+                    (sbyte)(this.Arguments.NewLocation.IsUnderground ? Math.Min(15, this.Arguments.NewLocation.Z + 2) : 0),
                     1,
                     IMap.DefaultWindowSizeY));
         }


### PR DESCRIPTION
Problem:
When a player would try to go to the deepest floor in the server, an index out of bounds exception would be thrown during sector load.

Solution:
Prevented by restricting description of only existing sectors.